### PR TITLE
Skip behavior:SKIP no longer ends the turn. It now moves the current …

### DIFF
--- a/apps/frontend/frontend-service/lib/api-client.ts
+++ b/apps/frontend/frontend-service/lib/api-client.ts
@@ -163,6 +163,18 @@ class ApiClient {
     });
   }
 
+  // Test Mode predictions via BFF unified route
+  async createTestModePrediction(data: {
+    userId: number;
+    fixtureId: number;
+    choice: '1' | 'X' | '2';
+  }) {
+    return this.request('/predictions', {
+      method: 'POST',
+      body: JSON.stringify({ ...data, mode: 'test' as const }),
+    });
+  }
+
   // Test Mode API
   async getTestFixtures(week: number = 1) {
     // Default to week 1 if no week specified

--- a/apps/frontend/frontend-service/package.json
+++ b/apps/frontend/frontend-service/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",
     "firebase": "^12.0.0",
+    "framer-motion": "^11.2.10",
     "next": "15.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0"
@@ -29,7 +30,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-  "eslint": "^8.57.0",
+    "eslint": "^8.57.0",
     "eslint-config-next": "15.4.5",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -521,6 +521,7 @@
       "dependencies": {
         "@ducanh2912/next-pwa": "^10.2.9",
         "firebase": "^12.0.0",
+        "framer-motion": "^11.2.10",
         "next": "15.4.5",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -11189,6 +11190,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -14523,6 +14551,21 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",


### PR DESCRIPTION
…card to the end of both fixtures and matchCards arrays and stays at the same index so the next card is shown. Progress still ignores SKIP.Proper user id lookup:On load, fetch /api/users/profile/firebase/:uid via the BFF and store the numeric userId in state.On commit (1/X/2), call the test-mode create prediction API using that numeric userId.Swipe + persist:Framer Motion added for smooth drags with no bounce-back. Direction mapping:left=1, up=X, down=SKIP, right=2On 1/X/2, persist via BFF, refresh matchCards (to update overlays), then advance to next card.On SKIP, no write, rotates current card to end.