### PR TITLE
Keep loading active while redirecting from Test week 1→2, instead of …

### DIFF
--- a/apps/frontend/frontend-service/app/gioca/page.tsx
+++ b/apps/frontend/frontend-service/app/gioca/page.tsx
@@ -1438,7 +1438,7 @@ function GiocaPageContent() {
           <div className="relative w-full max-w-xs mx-auto">
             <div className="bg-white bg-opacity-30 rounded-sm overflow-hidden" style={{ height: '18px' }}>
               <div
-                className="bg-indigo-300 h-full rounded-sm transition-all duration-350"
+                className="bg-indigo-300 h-full rounded-sm transition-all duration-[350ms]"
                 style={{ width: `${progressPct}%` }}
               />
             </div>
@@ -1452,7 +1452,7 @@ function GiocaPageContent() {
       </div>
 
       {/* Match Card Stack with Swipe */}
-  <div className="px-3 mb-8 relative max-w-[390px] mx-auto w-full" style={{ overscrollBehavior: 'contain', WebkitOverflowScrolling: 'touch', touchAction: 'pan-y' as React.CSSProperties['touchAction'] }}>
+  <div className="px-3 mb-8 relative max-w-[390px] mx-auto w-full" style={{ overscrollBehavior: 'contain', WebkitOverflowScrolling: 'touch', touchAction: 'pan-y' }}>
   {/* Next card preview to be revealed (hidden on very small screens to avoid visual spill) */}
   {effectiveFixtures[currentFixtureIndex + 1] && (
   <div className={`absolute inset-0 opacity-95 pointer-events-none ${previewOnTop ? 'z-20' : 'z-0'} scale-[0.94] sm:scale-[0.97]`}>


### PR DESCRIPTION
…briefly clearing loading.Treat “Test Mode + userKey not resolved yet” as loading.Removed an early setLoading(false) when userKey is missing so we don’t show empty state first.iOS swipe flash mitigationAdded compositing hints to the swipe card for Safari/Chrome on iOS:will-change: transform, backface-visibility: hidden, -webkit-backface-visibility: hidden, and translateZ(0).Set the deck wrapper to avoid horizontal overscroll interference:overscroll-behavior: contain, -webkit-overflow-scrolling: touch, touch-action: pan-y.Meter sync polishBoth the progress bar and label already share predictionsCount; slightly smoothed the width transition to reduce one-frame paint quirks on iOS.