### PR TITLE
🎨 Fix last 5 results color coding with historical match context

### DIFF
--- a/apps/backend/gaming-services/dist/main.js
+++ b/apps/backend/gaming-services/dist/main.js
@@ -119272,10 +119272,12 @@ let MatchCardsService = MatchCardsService_1 = class MatchCardsService {
         const teams = new Set(fixtures.flatMap(f => [f.home_team, f.away_team]));
         const last5ByTeam = new Map();
         const last5IdsByTeam = new Map();
+        const wasHomeFlagsByTeam = new Map();
         for (const team of teams) {
-            const { results, fixtureIds } = isWeekOne ? { results: [], fixtureIds: [] } : this.computeLast5WithIds(priorFixtures, team);
+            const { results, fixtureIds, wasHomeFlags } = isWeekOne ? { results: [], fixtureIds: [], wasHomeFlags: [] } : this.computeLast5WithIds(priorFixtures, team);
             last5ByTeam.set(team, results);
             last5IdsByTeam.set(team, fixtureIds);
+            wasHomeFlagsByTeam.set(team, wasHomeFlags);
         }
         let userPredictions = new Map();
         if (userId && !isWeekOne) {
@@ -119308,10 +119310,12 @@ let MatchCardsService = MatchCardsService_1 = class MatchCardsService {
             const awayLast5 = last5ByTeam.get(fixture.away_team) || [];
             const homeFixtureIds = last5IdsByTeam.get(fixture.home_team) || [];
             const awayFixtureIds = last5IdsByTeam.get(fixture.away_team) || [];
+            const homeWasHomeFlags = wasHomeFlagsByTeam.get(fixture.home_team) || [];
+            const awayWasHomeFlags = wasHomeFlagsByTeam.get(fixture.away_team) || [];
             const homeWinRate = isWeekOne ? null : this.computeWinRate(priorFixtures, fixture.home_team, 'home');
             const awayWinRate = isWeekOne ? null : this.computeWinRate(priorFixtures, fixture.away_team, 'away');
-            const homeForm = this.createFormWithOverlay(homeLast5, homeFixtureIds, userPredictions);
-            const awayForm = this.createFormWithOverlay(awayLast5, awayFixtureIds, userPredictions);
+            const homeForm = this.createFormWithOverlay(homeLast5, homeFixtureIds, userPredictions, homeWasHomeFlags);
+            const awayForm = this.createFormWithOverlay(awayLast5, awayFixtureIds, userPredictions, awayWasHomeFlags);
             const homeTeam = {
                 name: fixture.home_team,
                 logo: this.getTeamLogo(fixture.home_team),
@@ -119461,20 +119465,23 @@ let MatchCardsService = MatchCardsService_1 = class MatchCardsService {
             }
         });
         const fixtureIds = teamFixtures.map(f => f.id);
-        return { results, fixtureIds };
+        const wasHomeFlags = teamFixtures.map(f => f.home_team === teamName);
+        return { results, fixtureIds, wasHomeFlags };
     }
-    createFormWithOverlay(results, fixtureIds, userPredictions) {
+    createFormWithOverlay(results, fixtureIds, userPredictions, wasHomeFlags) {
         if (!results.length || !fixtureIds.length)
             return [];
         return results.map((code, index) => {
             const fixtureId = fixtureIds[index];
             const predicted = userPredictions.get(fixtureIds[index]) || null;
             const correct = predicted ? (predicted === code) : null;
+            const wasHome = wasHomeFlags[index] || false;
             return {
                 fixtureId,
                 code,
                 predicted,
                 correct,
+                wasHome,
             };
         });
     }

--- a/apps/backend/gaming-services/src/modules/match-cards/dto/match-cards.dto.ts
+++ b/apps/backend/gaming-services/src/modules/match-cards/dto/match-cards.dto.ts
@@ -6,6 +6,7 @@ export interface Last5ItemDto {
   code: ResultCode;
   predicted: ResultCode | null; // user prediction if exists
   correct: boolean | null; // null when no prediction
+  wasHome: boolean; // true if this team was home in this match
 }
 
 export interface MatchCardKickoffDto {

--- a/apps/backend/gaming-services/src/modules/match-cards/match-cards.service.ts
+++ b/apps/backend/gaming-services/src/modules/match-cards/match-cards.service.ts
@@ -66,12 +66,14 @@ export class MatchCardsService {
     const teams = new Set<string>(fixtures.flatMap(f => [f.home_team, f.away_team]));
     const last5ByTeam = new Map<string, ResultCode[]>();
     const last5IdsByTeam = new Map<string, string[]>();
+    const wasHomeFlagsByTeam = new Map<string, boolean[]>();
 
     // Calculate last 5 results and fixture IDs for each team
     for (const team of teams) {
-      const { results, fixtureIds } = isWeekOne ? { results: [], fixtureIds: [] } : this.computeLast5WithIds(priorFixtures, team);
+      const { results, fixtureIds, wasHomeFlags } = isWeekOne ? { results: [], fixtureIds: [], wasHomeFlags: [] } : this.computeLast5WithIds(priorFixtures, team);
       last5ByTeam.set(team, results);
       last5IdsByTeam.set(team, fixtureIds);
+      wasHomeFlagsByTeam.set(team, wasHomeFlags);
     }
 
     // Get user predictions for overlay if userId provided
@@ -108,13 +110,15 @@ export class MatchCardsService {
       const awayLast5 = last5ByTeam.get(fixture.away_team) || [];
       const homeFixtureIds = last5IdsByTeam.get(fixture.home_team) || [];
       const awayFixtureIds = last5IdsByTeam.get(fixture.away_team) || [];
+      const homeWasHomeFlags = wasHomeFlagsByTeam.get(fixture.home_team) || [];
+      const awayWasHomeFlags = wasHomeFlagsByTeam.get(fixture.away_team) || [];
 
       const homeWinRate = isWeekOne ? null : this.computeWinRate(priorFixtures, fixture.home_team, 'home');
       const awayWinRate = isWeekOne ? null : this.computeWinRate(priorFixtures, fixture.away_team, 'away');
 
       // Create form with user overlay
-      const homeForm = this.createFormWithOverlay(homeLast5, homeFixtureIds, userPredictions);
-      const awayForm = this.createFormWithOverlay(awayLast5, awayFixtureIds, userPredictions);
+      const homeForm = this.createFormWithOverlay(homeLast5, homeFixtureIds, userPredictions, homeWasHomeFlags);
+      const awayForm = this.createFormWithOverlay(awayLast5, awayFixtureIds, userPredictions, awayWasHomeFlags);
 
       const homeTeam: MatchCardTeamHomeDto = {
         name: fixture.home_team,
@@ -286,7 +290,7 @@ export class MatchCardsService {
   /**
    * Compute last 5 results with fixture IDs for a team
    */
-  private computeLast5WithIds(priorFixtures: Fixture[], teamName: string): { results: ResultCode[]; fixtureIds: string[] } {
+  private computeLast5WithIds(priorFixtures: Fixture[], teamName: string): { results: ResultCode[]; fixtureIds: string[]; wasHomeFlags: boolean[] } {
     const teamFixtures = priorFixtures
       .filter(f => f.home_team === teamName || f.away_team === teamName)
       .filter(f => f.home_score !== null && f.away_score !== null)
@@ -304,8 +308,9 @@ export class MatchCardsService {
     });
 
     const fixtureIds = teamFixtures.map(f => f.id);
+    const wasHomeFlags = teamFixtures.map(f => f.home_team === teamName);
     
-    return { results, fixtureIds };
+    return { results, fixtureIds, wasHomeFlags };
   }
 
   /**
@@ -314,7 +319,8 @@ export class MatchCardsService {
   private createFormWithOverlay(
     results: ResultCode[],
     fixtureIds: string[],
-    userPredictions: Map<string, ResultCode>
+    userPredictions: Map<string, ResultCode>,
+    wasHomeFlags: boolean[]
   ): Last5ItemDto[] {
     if (!results.length || !fixtureIds.length) return [];
 
@@ -322,12 +328,14 @@ export class MatchCardsService {
       const fixtureId = fixtureIds[index]; // Keep as string
       const predicted = userPredictions.get(fixtureIds[index]) || null;
       const correct = predicted ? (predicted === code) : null;
+      const wasHome = wasHomeFlags[index] || false;
 
       return {
         fixtureId,
         code,
         predicted,
         correct,
+        wasHome,
       };
     });
   }

--- a/apps/frontend/frontend-service/app/gioca/page.tsx
+++ b/apps/frontend/frontend-service/app/gioca/page.tsx
@@ -138,7 +138,7 @@ interface RawFixtureData {
 // Match-cards API types
 interface MatchCardKickoff { iso: string; display: string; }
 interface Last5Item {
-  fixtureId: number;
+  fixtureId: number | string;
   code: '1'|'X'|'2';
   // Optional: user prediction metadata (when applicable)
   predicted: '1'|'X'|'2'|null;
@@ -146,8 +146,8 @@ interface Last5Item {
   // Optional: backend-provided, team-perspective outcome for this historical item
   // 'W' = team won, 'D' = draw, 'L' = team lost
   outcome?: 'W'|'D'|'L' | null;
-  // Optional: whether this team was the home side in that specific historical match
-  teamWasHome?: boolean | null;
+  // Whether this team was the home side in that specific historical match
+  wasHome: boolean;
 }
 interface MatchCardTeamHome { name: string; logo: string | null; winRateHome: number | null; last5: Array<'1' | 'X' | '2'>; standingsPosition?: number|null; form?: Last5Item[]; }
 interface MatchCardTeamAway { name: string; logo: string | null; winRateAway: number | null; last5: Array<'1' | 'X' | '2'>; standingsPosition?: number|null; form?: Last5Item[]; }
@@ -1697,7 +1697,7 @@ function GiocaPageContent() {
     // Normalize to Last5Item[], pad to 5, then render right-to-left (most recent on the right)
     const base: (Last5Item | null)[] = (form && form.length)
       ? form
-      : list.map((code) => ({ fixtureId: 0, code, predicted: null, correct: null }));
+      : list.map((code) => ({ fixtureId: 0, code, predicted: null, correct: null, wasHome: false }));
     const filled: Array<Last5Item | null> = base.slice(0, 5);
     while (filled.length < 5) filled.push(null);
 
@@ -1719,18 +1719,41 @@ function GiocaPageContent() {
           }
           let color = 'bg-gray-100 text-gray-700';
           let titleStr: string = it.code;
-          const pick = it.predicted;
-          if (pick === '1' || pick === 'X' || pick === '2') {
-            if (pick === it.code) {
-              color = 'bg-[#ccffb3] text-[#2a8000]';
-              titleStr = `${it.code} — Corretto`;
+          
+          // Color based on team perspective (win/loss/draw)
+          if (it.code === 'X') {
+            // Draw - gray for both teams
+            color = 'bg-gray-100 text-gray-700';
+            titleStr = 'X — Pareggio';
+          } else if (it.wasHome !== undefined) {
+            // Win/Loss based on whether team was home/away in this specific match
+            // it.code: '1' = home won, '2' = away won
+            // it.wasHome: true = this team was home, false = this team was away
+            const isGoodResult = (it.wasHome && it.code === '1') || (!it.wasHome && it.code === '2');
+            if (isGoodResult) {
+              // Win - green with darker green text
+              color = 'bg-green-100 text-green-800 font-bold';
+              titleStr = `${it.code} — Vittoria`;
             } else {
-              color = 'bg-[#ffb3b3] text-[#cc0000]';
-              titleStr = `${it.code} — Errato`;
+              // Loss - red with darker red text  
+              color = 'bg-red-100 text-red-800 font-bold';
+              titleStr = `${it.code} — Sconfitta`;
             }
           } else {
-            color = 'bg-gray-100 text-gray-700';
-            titleStr = it.code;
+            // Fallback to prediction-based coloring if team perspective unknown
+            const pick = it.predicted;
+            if (pick === '1' || pick === 'X' || pick === '2') {
+              if (pick === it.code) {
+                color = 'bg-[#ccffb3] text-[#2a8000]';
+                titleStr = `${it.code} — Corretto`;
+              } else {
+                color = 'bg-[#ffb3b3] text-[#cc0000]';
+                titleStr = `${it.code} — Errato`;
+              }
+            } else {
+              color = 'bg-gray-100 text-gray-700';
+              titleStr = it.code;
+            }
           }
           return (
             <div


### PR DESCRIPTION
Enhanced match cards to show proper team-perspective colors:
- Backend: Added wasHome property to track each team's home/away status in historical matches
- Frontend: Updated color logic to use individual match context instead of current match position
- Colors now correctly reflect: Green=team won, Red=team lost, Gray=draw
- Fixed the issue where same result code showed different colors based on current position

