### PR TITLE
Backfill

### DIFF
--- a/Dockerfile.gaming-services
+++ b/Dockerfile.gaming-services
@@ -2,6 +2,9 @@
 # This Dockerfile must be at repo root and Railway must be configured to use it
 FROM node:20-alpine AS base
 
+# Cache busting - change this value to force rebuild
+ARG CACHE_BUST=v3_status_fix_20250930
+
 # Install dependencies only when needed
 FROM base AS deps
 WORKDIR /app

--- a/apps/backend/gaming-services/src/modules/live-updates/simple-match-polling.service.ts
+++ b/apps/backend/gaming-services/src/modules/live-updates/simple-match-polling.service.ts
@@ -51,19 +51,16 @@ export class SimpleMatchPollingService {
       '[SIMPLE_MATCH_POLLING_INIT] Timestamp: ' + new Date().toISOString(),
     );
     this.logger.log(
-      '[SIMPLE_MATCH_POLLING_INIT] Version: DYNAMIC_WEEK_DETECTION_V2_20250930',
+      '[SIMPLE_MATCH_POLLING_INIT] Version: V3_FIXED_STATUS_PATH_20250930_1200PM',
     );
     this.logger.log(
-      '[SIMPLE_MATCH_POLLING_INIT] Feature: 7-Day Window Scanning (Past + Future)',
+      '[SIMPLE_MATCH_POLLING_INIT] Fix: Status now reads from fixture.status.short',
     );
     this.logger.log(
-      '[SIMPLE_MATCH_POLLING_INIT] Feature: Automatic Week Detection',
+      '[SIMPLE_MATCH_POLLING_INIT] Feature: Smart backfill + checkpoint polling',
     );
     this.logger.log(
-      '[SIMPLE_MATCH_POLLING_INIT] Feature: Catches Missed Matches from Downtime',
-    );
-    this.logger.log(
-      '[SIMPLE_MATCH_POLLING_INIT] NO MORE HARDCODED WEEK 4 - DYNAMIC DETECTION ACTIVE!',
+      '[SIMPLE_MATCH_POLLING_INIT] Debug: Shows match status and scores in logs',
     );
     this.logger.log('='.repeat(80));
   }
@@ -79,6 +76,9 @@ export class SimpleMatchPollingService {
     if (process.env.DISABLE_LIVE_UPDATES === 'true') {
       return;
     }
+
+    // Log version on every run to confirm deployment
+    this.logger.log('📌 Running polling V3_FIXED_STATUS_PATH_20250930_1200PM');
 
     try {
       await this.resetDailyCounterIfNeeded();

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,7 @@
 [build]
 builder = "dockerfile"
 dockerfilePath = "Dockerfile.gaming-services"
+buildArgs = { CACHE_BUST = "v3_status_fix_20250930" }
 
 [deploy]
 startCommand = "node dist/main"


### PR DESCRIPTION
Backfill past matches every 5 minutes (checks past 10 days for matches with NULL scores)
Monitor future matches via database only (no API calls until checkpoint times)
Make API calls only at checkpoints: 5 minutes after scheduled kickoff and ~105 minutes after for match end
Status parsing fixed: Now correctly reads from fixture.status.short in API response