### PR TITLE
Fix CORS policy for production deployment

### DIFF
--- a/apps/backend/gaming-services/src/main.ts
+++ b/apps/backend/gaming-services/src/main.ts
@@ -77,9 +77,34 @@ async function bootstrap() {
   );
 
   // CORS configuration
+  const corsOrigins = [
+    'http://localhost:3000',
+    'http://localhost:4000',
+    'http://localhost:4200',
+    'https://swipick.com',
+    'https://www.swipick.com',
+    'https://swipick-frontend.vercel.app',
+    'https://swipick-frontend.up.railway.app',
+  ];
+
   app.enableCors({
-    origin: nodeEnv === 'production' ? false : true,
+    origin: (origin, callback) => {
+      // Allow requests with no origin (like mobile apps, Postman, etc.)
+      if (!origin) {
+        return callback(null, true);
+      }
+
+      // Check if origin is in allowed list
+      if (corsOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        logger.warn(`CORS blocked request from origin: ${origin}`);
+        callback(null, false);
+      }
+    },
     credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
   });
 
   // Global prefix


### PR DESCRIPTION
- Changed from blocking all origins in production to using an allowlist
- Added localhost ports (3000, 4000, 4200) for local development
- Added production domains (swipick.com, vercel, railway)
- Allow requests with no origin (mobile apps, Postman)
- Added proper CORS methods and headers configuration
- Logs blocked origins for debugging

This fixes the CORS error preventing frontend from accessing the backend API