### PR TITLE
Fase 5: season-aware data model + 2026 season support

### DIFF
--- a/apps/backend/gaming-services/package.json
+++ b/apps/backend/gaming-services/package.json
@@ -21,7 +21,8 @@
     "migration:run": "npm run typeorm -- migration:run -d typeorm.config.ts",
     "migration:revert": "npm run typeorm -- migration:revert -d typeorm.config.ts",
     "refresh:week6": "ts-node src/scripts/refresh-week-6-fixtures.ts",
-    "refresh:week7": "ts-node src/scripts/refresh-week-7-fixtures.ts"
+    "refresh:week7": "ts-node src/scripts/refresh-week-7-fixtures.ts",
+    "import:season": "ts-node src/scripts/import-season-fixtures.ts"
   },
   "dependencies": {
     "@nestjs/axios": "^3.1.3",

--- a/apps/backend/gaming-services/src/app.module.ts
+++ b/apps/backend/gaming-services/src/app.module.ts
@@ -8,6 +8,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { DatabaseConfig } from './config/database.config';
 import { ApiFootballConfig } from './config/api-football.config';
 import { WebSocketConfig } from './config/websocket.config';
+import { SeasonConfig } from './config/season.config';
 
 // Modules
 import { ApiFootballModule } from './modules/api-football/api-football.module';
@@ -20,6 +21,7 @@ import { SpecsModule } from './modules/specs/specs.module';
 import { TestModeModule } from './modules/test-mode/test-mode.module';
 import { MatchCardsModule } from './modules/match-cards/match-cards.module';
 import { FinalWeekScoresModule } from './modules/final-week-scores/final-week-scores.module';
+import { SeasonModule } from './modules/season/season.module';
 
 @Module({
   imports: [
@@ -27,7 +29,7 @@ import { FinalWeekScoresModule } from './modules/final-week-scores/final-week-sc
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: '../../../.env', // Path to root .env file
-      load: [DatabaseConfig, ApiFootballConfig, WebSocketConfig],
+      load: [DatabaseConfig, ApiFootballConfig, WebSocketConfig, SeasonConfig],
     }),
 
     // Database
@@ -45,6 +47,7 @@ import { FinalWeekScoresModule } from './modules/final-week-scores/final-week-sc
     ScheduleModule.forRoot(),
 
     // Application modules
+    SeasonModule,
     ApiFootballModule,
     FixturesModule,
     TeamsModule,

--- a/apps/backend/gaming-services/src/config/api-football.config.ts
+++ b/apps/backend/gaming-services/src/config/api-football.config.ts
@@ -32,7 +32,7 @@ export const ApiFootballConfig = registerAs(
         concurrentRequests: 2,
       },
       pro: {
-        requestsPerDay: 7500,  // Actual API-Football Pro limit
+        requestsPerDay: 7500, // Actual API-Football Pro limit
         requestsPerMinute: 100,
         concurrentRequests: 5,
       },

--- a/apps/backend/gaming-services/src/config/season.config.ts
+++ b/apps/backend/gaming-services/src/config/season.config.ts
@@ -1,0 +1,13 @@
+import { registerAs } from '@nestjs/config';
+
+export interface SeasonConfig {
+  /** Current Serie A season (start year). 2026 = season 2026-2027. */
+  current: number;
+}
+
+export const SeasonConfig = registerAs(
+  'season',
+  (): SeasonConfig => ({
+    current: parseInt(process.env.CURRENT_SEASON ?? '2025', 10),
+  }),
+);

--- a/apps/backend/gaming-services/src/database/migrations/1760000000000-AddSeasonColumns.ts
+++ b/apps/backend/gaming-services/src/database/migrations/1760000000000-AddSeasonColumns.ts
@@ -1,0 +1,102 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a `season` column to fixtures, specs and final_week_scores so the app
+ * can host multiple Serie A seasons without week (1-38) collisions, while
+ * preserving the 2025 history.
+ *
+ * Pattern per column: ADD with DEFAULT 2025 -> backfill -> SET NOT NULL.
+ * The DEFAULT 2025 keeps pre-season-aware code compatible during the rollout
+ * window (safe code rollback). final_week_scores' uniqueness is widened to
+ * include season so 2025 and 2026 scores for the same week coexist.
+ */
+export class AddSeasonColumns1760000000000 implements MigrationInterface {
+  name = 'AddSeasonColumns1760000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ---- fixtures ----
+    await queryRunner.query(
+      `ALTER TABLE "fixtures" ADD COLUMN IF NOT EXISTS "season" integer NOT NULL DEFAULT 2025`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_fixtures_season_week" ON "fixtures" ("season", "week")`,
+    );
+
+    // ---- specs ---- (backfill from the linked fixture, then enforce NOT NULL)
+    await queryRunner.query(
+      `ALTER TABLE "specs" ADD COLUMN IF NOT EXISTS "season" integer DEFAULT 2025`,
+    );
+    await queryRunner.query(
+      `UPDATE "specs" s SET "season" = f."season" FROM "fixtures" f WHERE s."fixture_id" = f."id" AND s."season" IS NULL`,
+    );
+    await queryRunner.query(
+      `UPDATE "specs" SET "season" = 2025 WHERE "season" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "specs" ALTER COLUMN "season" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_specs_user_season_week" ON "specs" ("user_id", "season", "week")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_specs_user_season_mode" ON "specs" ("user_id", "season", "mode")`,
+    );
+
+    // ---- final_week_scores ---- widen uniqueness to include season
+    await queryRunner.query(
+      `ALTER TABLE "final_week_scores" ADD COLUMN IF NOT EXISTS "season" integer NOT NULL DEFAULT 2025`,
+    );
+    // Drop the old [userId, week, mode] unique constraint, whatever its name.
+    await queryRunner.query(`
+      DO $$
+      DECLARE c text;
+      BEGIN
+        SELECT tc.constraint_name INTO c
+        FROM information_schema.table_constraints tc
+        WHERE tc.table_name = 'final_week_scores'
+          AND tc.constraint_type = 'UNIQUE'
+          AND tc.constraint_name NOT LIKE '%season%'
+        LIMIT 1;
+        IF c IS NOT NULL THEN
+          EXECUTE format('ALTER TABLE "final_week_scores" DROP CONSTRAINT %I', c);
+        END IF;
+      END $$;
+    `);
+    await queryRunner.query(
+      `ALTER TABLE "final_week_scores" ADD CONSTRAINT "UQ_fws_user_week_season_mode" UNIQUE ("userId", "week", "season", "mode")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_fws_week_season_mode" ON "final_week_scores" ("week", "season", "mode")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // NOTE: safe only while no 2026 data exists (restoring the 3-col unique
+    // would conflict if 2025 and 2026 rows share [userId, week, mode]).
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_fws_week_season_mode"`);
+    await queryRunner.query(
+      `ALTER TABLE "final_week_scores" DROP CONSTRAINT IF EXISTS "UQ_fws_user_week_season_mode"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "final_week_scores" ADD CONSTRAINT "UQ_fws_user_week_mode" UNIQUE ("userId", "week", "mode")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "final_week_scores" DROP COLUMN IF EXISTS "season"`,
+    );
+
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_specs_user_season_mode"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_specs_user_season_week"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "specs" DROP COLUMN IF EXISTS "season"`,
+    );
+
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_fixtures_season_week"`);
+    await queryRunner.query(
+      `ALTER TABLE "fixtures" DROP COLUMN IF EXISTS "season"`,
+    );
+  }
+}

--- a/apps/backend/gaming-services/src/entities/final-week-score.entity.ts
+++ b/apps/backend/gaming-services/src/entities/final-week-score.entity.ts
@@ -9,9 +9,10 @@ import {
 } from 'typeorm';
 
 @Entity('final_week_scores')
-@Unique(['userId', 'week', 'mode']) // One score per user per week per mode
+@Unique(['userId', 'week', 'season', 'mode']) // One score per user per week per season per mode
 @Index(['userId', 'mode']) // Optimize for user mode queries
 @Index(['week', 'mode']) // Optimize for week mode queries
+@Index(['week', 'season', 'mode']) // Season-scoped percentile/leaderboard
 export class FinalWeekScore {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -21,6 +22,10 @@ export class FinalWeekScore {
 
   @Column()
   week: number; // Week number (1-38)
+
+  // Serie A season (start year). DEFAULT 2025 keeps older code compatible.
+  @Column({ type: 'integer', default: 2025 })
+  season: number;
 
   @Column({
     type: 'enum',
@@ -75,10 +80,12 @@ export class FinalWeekScore {
     mode: 'live' | 'test',
     revealed: number,
     correct: number,
+    season = 2025,
   ): FinalWeekScore {
     const score = new FinalWeekScore();
     score.userId = userId;
     score.week = week;
+    score.season = season;
     score.mode = mode;
     score.revealed = revealed;
     score.correct = correct;

--- a/apps/backend/gaming-services/src/entities/fixture.entity.ts
+++ b/apps/backend/gaming-services/src/entities/fixture.entity.ts
@@ -12,9 +12,15 @@ import {
 @Index(['week'])
 @Index(['match_date'])
 @Index(['status'])
+@Index(['season', 'week'])
 export class Fixture {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  // Serie A season (start year). 2025 = 2025-26, 2026 = 2026-27.
+  // DEFAULT 2025 at the DB level keeps older code compatible during rollout.
+  @Column({ type: 'integer', nullable: false, default: 2025 })
+  season: number;
 
   @Column({ type: 'varchar', length: 100, nullable: false })
   home_team: string;

--- a/apps/backend/gaming-services/src/entities/spec.entity.ts
+++ b/apps/backend/gaming-services/src/entities/spec.entity.ts
@@ -16,6 +16,8 @@ import {
 @Index(['user_id', 'week'])
 @Index(['user_id', 'mode'])
 @Index(['mode'])
+@Index(['user_id', 'season', 'week'])
+@Index(['user_id', 'season', 'mode'])
 export class Spec {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -47,6 +49,10 @@ export class Spec {
   @Column({ type: 'integer', nullable: false })
   @Index()
   week: number;
+
+  // Denormalized from fixture.season (like week) for fast season-scoped stats.
+  @Column({ type: 'integer', nullable: false, default: 2025 })
+  season: number;
 
   @Column({
     type: 'enum',

--- a/apps/backend/gaming-services/src/modules/api-football/api-football.client.ts
+++ b/apps/backend/gaming-services/src/modules/api-football/api-football.client.ts
@@ -68,7 +68,7 @@ export class ApiFootballClient {
         teams: any;
         goals: any;
         score: any;
-      }>
+      }>;
     }>(endpoint, params);
 
     // Transform API response to match Fixture interface (flatten structure)
@@ -100,7 +100,7 @@ export class ApiFootballClient {
         goals: any;
         score: any;
         events?: any[];
-      }>
+      }>;
     }>(endpoint, params);
 
     // Transform API response to match LiveMatch interface (flatten structure)
@@ -154,7 +154,7 @@ export class ApiFootballClient {
         teams: any;
         goals: any;
         score: any;
-      }>
+      }>;
     }>(endpoint, params);
 
     // Transform API response to match Fixture interface (flatten structure)

--- a/apps/backend/gaming-services/src/modules/api-football/api-football.service.ts
+++ b/apps/backend/gaming-services/src/modules/api-football/api-football.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ApiFootballClient } from './api-football.client';
 import { CacheService } from '../cache/cache.service';
+import { SeasonConfigService } from '../season/season-config.service';
 
 // Interfaces
 import { Fixture, LiveMatch } from './interfaces/fixture.interface';
@@ -17,6 +18,7 @@ export class ApiFootballService {
   constructor(
     private readonly apiFootballClient: ApiFootballClient,
     private readonly cacheService: CacheService,
+    private readonly seasonConfig: SeasonConfigService,
   ) {}
 
   async getDailyFixtures(date: string): Promise<Fixture[]> {
@@ -33,7 +35,7 @@ export class ApiFootballService {
     const fixtures = await this.apiFootballClient.getFixtures({
       date,
       league: 135,
-      season: 2025,
+      season: this.seasonConfig.getCurrentSeason(),
     });
 
     // Cache for 2 minutes (matches polling frequency for real-time score updates)
@@ -61,7 +63,9 @@ export class ApiFootballService {
       await this.cacheService.set(cacheKey, fixture, 5 * 60); // 5-min TTL
     }
 
-    this.logger.log(`Fetched fixture by ID ${apiId}: ${fixture ? 'found' : 'not found'}`);
+    this.logger.log(
+      `Fetched fixture by ID ${apiId}: ${fixture ? 'found' : 'not found'}`,
+    );
     return fixture;
   }
 

--- a/apps/backend/gaming-services/src/modules/final-week-scores/dto/final-week-scores.dto.ts
+++ b/apps/backend/gaming-services/src/modules/final-week-scores/dto/final-week-scores.dto.ts
@@ -1,4 +1,11 @@
-import { IsEnum, IsNumber, IsString, Min, Max } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  Max,
+} from 'class-validator';
 
 export class CreateFinalWeekScoreDto {
   @IsString({ message: 'userId must be a string' })
@@ -8,6 +15,11 @@ export class CreateFinalWeekScoreDto {
   @Min(1, { message: 'week must be at least 1' })
   @Max(38, { message: 'week must be at most 38' })
   week: number;
+
+  // Optional: defaults to the current season (live) on the server.
+  @IsOptional()
+  @IsNumber({}, { message: 'season must be a number' })
+  season?: number;
 
   @IsEnum(['live', 'test'], {
     message: 'mode must be either live or test',

--- a/apps/backend/gaming-services/src/modules/final-week-scores/final-week-scores.season.spec.ts
+++ b/apps/backend/gaming-services/src/modules/final-week-scores/final-week-scores.season.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { FinalWeekScoresService } from './final-week-scores.service';
+import { FinalWeekScore } from '../../entities/final-week-score.entity';
+import { SeasonConfigService } from '../season/season-config.service';
+
+describe('FinalWeekScoresService — season scoping (live only)', () => {
+  let service: FinalWeekScoresService;
+  let repo: { query: jest.Mock };
+
+  beforeEach(async () => {
+    repo = { query: jest.fn().mockResolvedValue([]) };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FinalWeekScoresService,
+        { provide: getRepositoryToken(FinalWeekScore), useValue: repo },
+        {
+          provide: SeasonConfigService,
+          useValue: { getCurrentSeason: () => 2026 },
+        },
+      ],
+    }).compile();
+    service = module.get(FinalWeekScoresService);
+  });
+
+  it('percentile (live) filters by current season — 2025 and 2026 never mix', async () => {
+    await service.getUserPercentile('u1', 38, 'live');
+    const [sql, params] = repo.query.mock.calls[0];
+    expect(sql).toContain('final_week_scores');
+    expect(sql).toContain('season = $2');
+    expect(params).toEqual([38, 2026]);
+  });
+
+  it('percentile (test) does NOT add a season filter (separate table)', async () => {
+    await service.getUserPercentile('u1', 38, 'test');
+    const [sql, params] = repo.query.mock.calls[0];
+    expect(sql).toContain('test_final_week_scores');
+    expect(sql).not.toContain('season');
+    expect(params).toEqual([38]);
+  });
+
+  it('statistics (live) filters by current season', async () => {
+    await service.getUserStatistics('u1', 'live');
+    const [sql, params] = repo.query.mock.calls[0];
+    expect(sql).toContain('season = $2');
+    expect(params).toEqual(['u1', 2026]);
+  });
+
+  it('statistics (test) is not season-scoped', async () => {
+    await service.getUserStatistics('u1', 'test');
+    const [sql, params] = repo.query.mock.calls[0];
+    expect(sql).toContain('test_final_week_scores');
+    expect(sql).not.toContain('season');
+    expect(params).toEqual(['u1']);
+  });
+});

--- a/apps/backend/gaming-services/src/modules/final-week-scores/final-week-scores.service.ts
+++ b/apps/backend/gaming-services/src/modules/final-week-scores/final-week-scores.service.ts
@@ -12,6 +12,7 @@ import {
   FinalWeekScoreResponseDto,
   UserFinalScoresResponseDto,
 } from './dto/final-week-scores.dto';
+import { SeasonConfigService } from '../season/season-config.service';
 
 @Injectable()
 export class FinalWeekScoresService {
@@ -20,17 +21,29 @@ export class FinalWeekScoresService {
   constructor(
     @InjectRepository(FinalWeekScore)
     private readonly finalWeekScoreRepository: Repository<FinalWeekScore>,
+    private readonly seasonConfig: SeasonConfigService,
   ) {}
+
+  /**
+   * Season used for scoping. Only the LIVE table is season-aware; the test
+   * scores live in a separate, season-agnostic table, so test stays pinned to
+   * the default season and is never filtered out by a season flip.
+   */
+  private seasonFor(mode: 'live' | 'test'): number {
+    return mode === 'live' ? this.seasonConfig.getCurrentSeason() : 2025;
+  }
 
   async createOrUpdateFinalWeekScore(
     dto: CreateFinalWeekScoreDto,
   ): Promise<FinalWeekScoreResponseDto> {
+    const season = dto.season ?? this.seasonFor(dto.mode);
     try {
       // Try to find existing score
       const existingScore = await this.finalWeekScoreRepository.findOne({
         where: {
           userId: dto.userId,
           week: dto.week,
+          season,
           mode: dto.mode,
         },
       });
@@ -52,6 +65,7 @@ export class FinalWeekScoresService {
           dto.mode,
           dto.revealed,
           dto.correct,
+          season,
         );
         finalWeekScore =
           await this.finalWeekScoreRepository.save(finalWeekScore);
@@ -78,6 +92,7 @@ export class FinalWeekScoresService {
       where: {
         userId,
         week,
+        season: this.seasonFor(mode),
         mode,
       },
     });
@@ -98,6 +113,10 @@ export class FinalWeekScoresService {
     const whereClause: any = { userId };
     if (mode) {
       whereClause.mode = mode;
+      whereClause.season = this.seasonFor(mode);
+    } else {
+      // Live-only season scoping; without a mode we default to current live season.
+      whereClause.season = this.seasonConfig.getCurrentSeason();
     }
 
     const scores = await this.finalWeekScoreRepository.find({
@@ -132,6 +151,7 @@ export class FinalWeekScoresService {
     const result = await this.finalWeekScoreRepository.delete({
       userId,
       week,
+      season: this.seasonFor(mode),
       mode,
     });
 
@@ -175,16 +195,22 @@ export class FinalWeekScoresService {
         `📊 [PERCENTILE] Calculating percentile for user ${userId}, week ${week}, mode: ${mode}`,
       );
 
-      // Get all scores for this week
+      // Get all scores for this week. Only the live table is season-scoped.
       const tableName =
         mode === 'test' ? 'test_final_week_scores' : 'final_week_scores';
 
       this.logger.log(`📊 [PERCENTILE] Querying table: ${tableName}`);
 
-      const allScores = await this.finalWeekScoreRepository.query(
-        `SELECT "userId" as user_id, percent FROM ${tableName} WHERE week = $1 AND percent IS NOT NULL ORDER BY percent DESC`,
-        [week],
-      );
+      const allScores =
+        mode === 'live'
+          ? await this.finalWeekScoreRepository.query(
+              `SELECT "userId" as user_id, percent FROM ${tableName} WHERE week = $1 AND season = $2 AND percent IS NOT NULL ORDER BY percent DESC`,
+              [week, this.seasonConfig.getCurrentSeason()],
+            )
+          : await this.finalWeekScoreRepository.query(
+              `SELECT "userId" as user_id, percent FROM ${tableName} WHERE week = $1 AND percent IS NOT NULL ORDER BY percent DESC`,
+              [week],
+            );
 
       if (allScores.length === 0) {
         this.logger.log(`📊 [PERCENTILE] No scores found for week ${week}`);
@@ -275,11 +301,18 @@ export class FinalWeekScoresService {
 
       this.logger.log(`📊 [STATISTICS] Querying table: ${tableName}`);
 
-      // Get all user's scores
-      const userScores = await this.finalWeekScoreRepository.query(
-        `SELECT week, percent FROM ${tableName} WHERE "userId" = $1 AND percent IS NOT NULL ORDER BY percent DESC`,
-        [userId],
-      );
+      // Get all user's scores. Only the live table is season-scoped, so stats
+      // (average/best/weeksPlayed) are per-season and 2025/2026 never mix.
+      const userScores =
+        mode === 'live'
+          ? await this.finalWeekScoreRepository.query(
+              `SELECT week, percent FROM ${tableName} WHERE "userId" = $1 AND season = $2 AND percent IS NOT NULL ORDER BY percent DESC`,
+              [userId, this.seasonConfig.getCurrentSeason()],
+            )
+          : await this.finalWeekScoreRepository.query(
+              `SELECT week, percent FROM ${tableName} WHERE "userId" = $1 AND percent IS NOT NULL ORDER BY percent DESC`,
+              [userId],
+            );
 
       if (userScores.length === 0) {
         this.logger.log(`📊 [STATISTICS] No scores found for user ${userId}`);

--- a/apps/backend/gaming-services/src/modules/fixtures/fixture-integrity.ts
+++ b/apps/backend/gaming-services/src/modules/fixtures/fixture-integrity.ts
@@ -77,7 +77,8 @@ export const analyzeWeekIntegrity = (
   };
 
   if (report.missingFixtures > 0) report.issues.push('MISSING_FIXTURES');
-  if (report.unresolvedResults > 0) report.issues.push('UNRESOLVED_PAST_RESULTS');
+  if (report.unresolvedResults > 0)
+    report.issues.push('UNRESOLVED_PAST_RESULTS');
   // A genuine single-day giornata (contemporaneità) has different kickoff
   // times; seed placeholders put every match at the same identical instant.
   const distinctInstants = new Set(times);

--- a/apps/backend/gaming-services/src/modules/fixtures/fixtures.controller.ts
+++ b/apps/backend/gaming-services/src/modules/fixtures/fixtures.controller.ts
@@ -52,14 +52,35 @@ export class FixturesController {
     return this.fixturesService.getNextRealFixtures(lim, fromDate, userId);
   }
 
+  // Most recent (season, week) with at least one played match — drives the
+  // Risultati screen's initial open. Declared BEFORE ':id' so the generic
+  // route doesn't capture "last-played".
+  @Get('last-played')
+  async getLastPlayed() {
+    const result = await this.fixturesService.getLastPlayedWeek();
+    return result ?? { season: 2025, week: 1 };
+  }
+
   @Get('week/:weekNumber')
-  async getFixturesByWeek(@Param('weekNumber') weekNumber: number) {
-    return this.fixturesService.getFixturesByWeek(weekNumber);
+  async getFixturesByWeek(
+    @Param('weekNumber') weekNumber: number,
+    @Query('season') season?: number,
+  ) {
+    return this.fixturesService.getFixturesByWeek(
+      weekNumber,
+      season ? Number(season) : undefined,
+    );
   }
 
   @Get('week/:weekNumber/daterange')
-  async getWeekDateRange(@Param('weekNumber') weekNumber: number) {
-    return this.fixturesService.getWeekDateRange(weekNumber);
+  async getWeekDateRange(
+    @Param('weekNumber') weekNumber: number,
+    @Query('season') season?: number,
+  ) {
+    return this.fixturesService.getWeekDateRange(
+      weekNumber,
+      season ? Number(season) : undefined,
+    );
   }
 
   @Get(':id')
@@ -79,8 +100,7 @@ export class FixturesController {
 
   @Post('sync/season')
   async syncAllSeasonFixtures(@Body() body: { season?: number }) {
-    const season = body?.season || 2025;
-    return await this.fixturesService.syncAllSeasonFixtures(season);
+    return await this.fixturesService.syncAllSeasonFixtures(body?.season);
   }
 
   @Get('quota/status')

--- a/apps/backend/gaming-services/src/modules/fixtures/fixtures.service.spec.ts
+++ b/apps/backend/gaming-services/src/modules/fixtures/fixtures.service.spec.ts
@@ -1,0 +1,116 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { FixturesService } from './fixtures.service';
+import { Fixture } from '../../entities/fixture.entity';
+import { ApiFootballService } from '../api-football/api-football.service';
+import { ApiRateLimitService } from '../api-rate-limit/api-rate-limit.service';
+import { DatabasePersistenceService } from '../database-persistence/database-persistence.service';
+import { SeasonConfigService } from '../season/season-config.service';
+
+describe('FixturesService — season awareness', () => {
+  let service: FixturesService;
+  let qb: Record<string, jest.Mock>;
+  let fixtureRepository: { find: jest.Mock; createQueryBuilder: jest.Mock };
+  let currentSeason: number;
+
+  beforeEach(async () => {
+    currentSeason = 2026;
+    qb = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getRawOne: jest.fn(),
+      getMany: jest.fn().mockResolvedValue([]),
+    };
+    fixtureRepository = {
+      find: jest.fn().mockResolvedValue([]),
+      createQueryBuilder: jest.fn().mockReturnValue(qb),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FixturesService,
+        { provide: getRepositoryToken(Fixture), useValue: fixtureRepository },
+        { provide: ApiFootballService, useValue: {} },
+        { provide: ApiRateLimitService, useValue: {} },
+        { provide: DatabasePersistenceService, useValue: {} },
+        {
+          provide: SeasonConfigService,
+          useValue: { getCurrentSeason: () => currentSeason },
+        },
+      ],
+    }).compile();
+
+    service = module.get(FixturesService);
+  });
+
+  describe('getLastPlayedWeek', () => {
+    it('returns {season, week} from the most recent FINISHED giornata', async () => {
+      qb.getRawOne.mockResolvedValue({ season: '2025', week: '38' });
+      expect(await service.getLastPlayedWeek()).toEqual({
+        season: 2025,
+        week: 38,
+      });
+    });
+
+    it('returns the new season once it has a played match', async () => {
+      qb.getRawOne.mockResolvedValue({ season: '2026', week: '1' });
+      expect(await service.getLastPlayedWeek()).toEqual({
+        season: 2026,
+        week: 1,
+      });
+    });
+
+    it('returns null when nothing has been played yet', async () => {
+      qb.getRawOne.mockResolvedValue(undefined);
+      expect(await service.getLastPlayedWeek()).toBeNull();
+    });
+
+    it('returns null (not a throw) on query error', async () => {
+      qb.getRawOne.mockRejectedValue(new Error('db down'));
+      expect(await service.getLastPlayedWeek()).toBeNull();
+    });
+  });
+
+  describe('getFixturesByWeek', () => {
+    it('defaults to the current season', async () => {
+      await service.getFixturesByWeek(35);
+      expect(fixtureRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { week: 35, season: 2026 } }),
+      );
+    });
+
+    it('honours an explicit season (history during the gap)', async () => {
+      await service.getFixturesByWeek(38, 2025);
+      expect(fixtureRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { week: 38, season: 2025 } }),
+      );
+    });
+  });
+
+  describe('getNextRealFixtures (Gioca)', () => {
+    it('filters by the current season so it opens on the new-season week', async () => {
+      qb.getMany.mockResolvedValue([
+        {
+          week: 1,
+          season: 2026,
+          match_date: new Date('2026-08-23T16:30:00Z'),
+          status: 'SCHEDULED',
+          home_team: 'Udinese',
+          away_team: 'Como',
+          stadium: null,
+          external_api_id: null,
+        } as any,
+      ]);
+      const res: any = await service.getNextRealFixtures(10);
+      expect(qb.andWhere).toHaveBeenCalledWith('fx.season = :season', {
+        season: 2026,
+      });
+      expect(res.detectedWeek).toBe(1);
+    });
+  });
+});

--- a/apps/backend/gaming-services/src/modules/fixtures/fixtures.service.ts
+++ b/apps/backend/gaming-services/src/modules/fixtures/fixtures.service.ts
@@ -9,6 +9,7 @@ import {
   LiveMatch,
 } from '../api-football/interfaces/fixture.interface';
 import { Fixture as FixtureEntity } from '../../entities/fixture.entity';
+import { SeasonConfigService } from '../season/season-config.service';
 
 interface CacheEntry<T> {
   data: T;
@@ -30,6 +31,7 @@ export class FixturesService {
     private readonly apiFootballService: ApiFootballService,
     private readonly rateLimitService: ApiRateLimitService,
     private readonly dbPersistenceService: DatabasePersistenceService,
+    private readonly seasonConfig: SeasonConfigService,
   ) {}
 
   async syncFixturesForDate(date: string): Promise<Fixture[]> {
@@ -188,15 +190,19 @@ export class FixturesService {
   /**
    * Get fixtures by week number from local database
    */
-  async getFixturesByWeek(weekNumber: number): Promise<FixtureEntity[]> {
+  async getFixturesByWeek(
+    weekNumber: number,
+    season?: number,
+  ): Promise<FixtureEntity[]> {
+    const targetSeason = season ?? this.seasonConfig.getCurrentSeason();
     try {
       const fixtures = await this.fixtureRepository.find({
-        where: { week: weekNumber },
+        where: { week: weekNumber, season: targetSeason },
         order: { match_date: 'ASC' },
       });
 
       this.logger.debug(
-        `Retrieved ${fixtures.length} fixtures for week ${weekNumber} from database`,
+        `Retrieved ${fixtures.length} fixtures for week ${weekNumber} (season ${targetSeason}) from database`,
       );
 
       return fixtures;
@@ -209,7 +215,10 @@ export class FixturesService {
   /**
    * Get date range for a specific week from database fixtures
    */
-  async getWeekDateRange(weekNumber: number): Promise<{
+  async getWeekDateRange(
+    weekNumber: number,
+    season?: number,
+  ): Promise<{
     week: number;
     startDate: string;
     endDate: string;
@@ -217,9 +226,10 @@ export class FixturesService {
     endDateFormatted: string;
     fixtureCount: number;
   } | null> {
+    const targetSeason = season ?? this.seasonConfig.getCurrentSeason();
     try {
       const fixtures = await this.fixtureRepository.find({
-        where: { week: weekNumber },
+        where: { week: weekNumber, season: targetSeason },
         order: { match_date: 'ASC' },
       });
 
@@ -283,7 +293,10 @@ export class FixturesService {
 
       // 2. Check database persistence (medium speed)
       const persistedFixtures =
-        await this.dbPersistenceService.getPersistedSerieAFixtures(2025, days);
+        await this.dbPersistenceService.getPersistedSerieAFixtures(
+          this.seasonConfig.getCurrentSeason(),
+          days,
+        );
       if (persistedFixtures && persistedFixtures.length > 0) {
         this.logger.log(
           `📦 Retrieved ${persistedFixtures.length} Serie A fixtures from database`,
@@ -350,7 +363,7 @@ export class FixturesService {
         );
         await this.dbPersistenceService.persistSerieAFixtures(
           finalFixtures,
-          2025,
+          this.seasonConfig.getCurrentSeason(),
         );
 
         this.logger.log(
@@ -392,10 +405,12 @@ export class FixturesService {
   ) {
     try {
       const start = fromDate ? new Date(fromDate) : new Date();
+      const season = this.seasonConfig.getCurrentSeason();
       // Query TypeORM repository for upcoming fixtures (scheduled or live but not finished)
       const qb = this.fixtureRepository
         .createQueryBuilder('fx')
         .where('fx.match_date >= :start', { start })
+        .andWhere('fx.season = :season', { season })
         .andWhere('fx.status IN (:...statuses)', {
           statuses: ['SCHEDULED', 'LIVE'],
         })
@@ -418,6 +433,7 @@ export class FixturesService {
       if (entities.length === 0) {
         const recent = await this.fixtureRepository
           .createQueryBuilder('fx')
+          .where('fx.season = :season', { season })
           .orderBy('fx.match_date', 'DESC')
           .limit(Math.min(5, limit))
           .getMany();
@@ -443,6 +459,34 @@ export class FixturesService {
     }
   }
 
+  /**
+   * The most recent (season, week) that has at least one FINISHED fixture.
+   * Drives the Risultati screen's initial open: during the pre-season gap it
+   * returns the previous season's last giornata (e.g. {2025, 38}); once the
+   * current season has a played match it returns {currentSeason, latestWeek}.
+   */
+  async getLastPlayedWeek(): Promise<{ season: number; week: number } | null> {
+    try {
+      const row = await this.fixtureRepository
+        .createQueryBuilder('fx')
+        .select('fx.season', 'season')
+        .addSelect('MAX(fx.week)', 'week')
+        .where('fx.status = :status', { status: 'FINISHED' })
+        .andWhere(
+          'fx.season = (SELECT MAX(f2.season) FROM fixtures f2 WHERE f2.status = :status)',
+          { status: 'FINISHED' },
+        )
+        .groupBy('fx.season')
+        .getRawOne<{ season: string; week: string }>();
+
+      if (!row) return null;
+      return { season: Number(row.season), week: Number(row.week) };
+    } catch (error) {
+      this.logger.error('Failed to get last played week', error);
+      return null;
+    }
+  }
+
   /** Map DB fixture entity into the public (subset) Fixture API shape the frontend already expects */
   private mapEntityToApiFixture(e: FixtureEntity): Fixture {
     // Minimal mapping; fill league.round as Regular Season - {week}
@@ -461,7 +505,7 @@ export class FixturesService {
         name: 'Serie A',
         country: 'Italy',
         logo: 'https://media.api-sports.io/football/leagues/135.png',
-        season: new Date().getFullYear(),
+        season: e.season,
         round: `Regular Season - ${e.week}`,
       },
       teams: {
@@ -795,14 +839,17 @@ export class FixturesService {
   /**
    * Sync all Serie A 2025 fixtures in bulk from API-Football using single API call
    */
-  async syncAllSeasonFixtures(season: number = 2025): Promise<{
+  async syncAllSeasonFixtures(season?: number): Promise<{
     success: boolean;
     message: string;
     syncedCount: number;
     existingCount: number;
   }> {
+    const targetSeason = season ?? this.seasonConfig.getCurrentSeason();
     try {
-      this.logger.log(`🚀 Starting bulk Serie A ${season} fixtures sync...`);
+      this.logger.log(
+        `🚀 Starting bulk Serie A ${targetSeason} fixtures sync...`,
+      );
 
       // Check existing fixtures count
       const existingCount = await this.fixtureRepository.count();
@@ -838,12 +885,12 @@ export class FixturesService {
 
       // Fetch all Serie A 2025 fixtures using the service method that makes one API call
       this.logger.log(
-        `🌐 Fetching all Serie A ${season} fixtures from API-Football...`,
+        `🌐 Fetching all Serie A ${targetSeason} fixtures from API-Football...`,
       );
 
       const apiFixtures = await this.apiFootballService.getFixtures({
         league: 135,
-        season,
+        season: targetSeason,
       });
 
       this.logger.log(
@@ -852,7 +899,7 @@ export class FixturesService {
 
       if (apiFixtures.length === 0) {
         throw new Error(
-          `No fixtures returned from API-Football for Serie A ${season}`,
+          `No fixtures returned from API-Football for Serie A ${targetSeason}`,
         );
       }
 
@@ -905,6 +952,7 @@ export class FixturesService {
             apiFixture.venue?.name ||
             'TBD',
           week: week,
+          season: targetSeason,
           result: result,
           home_score: homeGoals,
           away_score: awayGoals,
@@ -965,8 +1013,11 @@ export class FixturesService {
       // 2. Currently LIVE
       const activeMatches = await this.fixtureRepository
         .createQueryBuilder('fixture')
-        .where(
-          '(fixture.status = :scheduled AND fixture.match_date >= :today AND fixture.match_date < :tomorrow) OR fixture.status = :live',
+        .where('fixture.season = :season', {
+          season: this.seasonConfig.getCurrentSeason(),
+        })
+        .andWhere(
+          '((fixture.status = :scheduled AND fixture.match_date >= :today AND fixture.match_date < :tomorrow) OR fixture.status = :live)',
           {
             scheduled: 'SCHEDULED',
             live: 'LIVE',

--- a/apps/backend/gaming-services/src/modules/live-updates/simple-match-polling.service.ts
+++ b/apps/backend/gaming-services/src/modules/live-updates/simple-match-polling.service.ts
@@ -7,6 +7,7 @@ import { CacheService } from '../cache/cache.service';
 import { FixturesService } from '../fixtures/fixtures.service';
 import { Fixture } from '../../entities/fixture.entity';
 import { Fixture as ApiFixture } from '../api-football/interfaces/fixture.interface';
+import { SeasonConfigService } from '../season/season-config.service';
 
 interface MatchCheckpoint {
   id: string;
@@ -37,6 +38,7 @@ export class SimpleMatchPollingService {
     private readonly fixturesService: FixturesService,
     private readonly apiFootballService: ApiFootballService,
     private readonly cacheService: CacheService,
+    private readonly seasonConfig: SeasonConfigService,
   ) {
     this.initializeDailyTracking();
     this.logServiceVersion();
@@ -121,8 +123,10 @@ export class SimpleMatchPollingService {
       // of the query and are never backfilled again. API usage stays bounded
       // by limit(10) + canMakeApiCall().
       const windowStart = new Date(
-        now.getTime() - SimpleMatchPollingService.BACKFILL_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+        now.getTime() -
+          SimpleMatchPollingService.BACKFILL_WINDOW_DAYS * 24 * 60 * 60 * 1000,
       );
+      const season = this.seasonConfig.getCurrentSeason();
 
       this.logger.log(
         `🔍 [BACKFILL_QUERY] Searching for past matches with NULL scores...`,
@@ -136,6 +140,7 @@ export class SimpleMatchPollingService {
         .createQueryBuilder('fixture')
         .where('fixture.match_date < :now', { now })
         .andWhere('fixture.match_date > :windowStart', { windowStart })
+        .andWhere('fixture.season = :season', { season })
         .andWhere('(fixture.home_score IS NULL OR fixture.away_score IS NULL)')
         .orderBy('fixture.match_date', 'ASC')
         .limit(20)
@@ -159,6 +164,7 @@ export class SimpleMatchPollingService {
         .createQueryBuilder('fixture')
         .where('fixture.match_date < :now', { now })
         .andWhere('fixture.match_date > :windowStart', { windowStart })
+        .andWhere('fixture.season = :season', { season })
         .andWhere('(fixture.home_score IS NULL OR fixture.away_score IS NULL)')
         .andWhere('fixture.status != :finished', { finished: 'FINISHED' })
         .orderBy('fixture.match_date', 'ASC')

--- a/apps/backend/gaming-services/src/modules/match-cards/match-cards.controller.ts
+++ b/apps/backend/gaming-services/src/modules/match-cards/match-cards.controller.ts
@@ -9,7 +9,12 @@ export class MatchCardsController {
   async getMatchCardsByWeek(
     @Param('weekNumber') weekNumber: number,
     @Query('userId') userId?: string,
+    @Query('season') season?: number,
   ) {
-    return this.matchCardsService.getMatchCardsByWeek(weekNumber, userId);
+    return this.matchCardsService.getMatchCardsByWeek(
+      weekNumber,
+      userId,
+      season ? Number(season) : undefined,
+    );
   }
 }

--- a/apps/backend/gaming-services/src/modules/match-cards/match-cards.service.ts
+++ b/apps/backend/gaming-services/src/modules/match-cards/match-cards.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
 import { Fixture } from '../../entities/fixture.entity';
 import { Spec } from '../../entities/spec.entity';
+import { SeasonConfigService } from '../season/season-config.service';
 import {
   MatchCardDto,
   MatchCardKickoffDto,
@@ -28,6 +29,7 @@ export class MatchCardsService {
     private readonly fixtureRepository: Repository<Fixture>,
     @InjectRepository(Spec)
     private readonly specRepository: Repository<Spec>,
+    private readonly seasonConfig: SeasonConfigService,
   ) {}
 
   /**
@@ -36,8 +38,10 @@ export class MatchCardsService {
   async getMatchCardsByWeek(
     weekNumber: number,
     userId?: string,
+    season?: number,
   ): Promise<MatchCardDto[]> {
-    const cacheKey = `live-match-cards-${weekNumber}-${userId || 'anonymous'}`;
+    const targetSeason = season ?? this.seasonConfig.getCurrentSeason();
+    const cacheKey = `live-match-cards-${targetSeason}-${weekNumber}-${userId || 'anonymous'}`;
     const cached = this.matchCardsCache.get(cacheKey);
 
     if (cached && cached.expiresAt > Date.now()) {
@@ -47,7 +51,7 @@ export class MatchCardsService {
 
     // Get fixtures for the requested week
     const fixtures = await this.fixtureRepository.find({
-      where: { week: weekNumber },
+      where: { week: weekNumber, season: targetSeason },
       order: { match_date: 'ASC' },
     });
 
@@ -65,6 +69,7 @@ export class MatchCardsService {
       : await this.fixtureRepository
           .createQueryBuilder('fixture')
           .where('fixture.week <= :week', { week: weekNumber })
+          .andWhere('fixture.season = :season', { season: targetSeason })
           .andWhere(
             'fixture.home_score IS NOT NULL AND fixture.away_score IS NOT NULL',
           )

--- a/apps/backend/gaming-services/src/modules/predictions/predictions.service.ts
+++ b/apps/backend/gaming-services/src/modules/predictions/predictions.service.ts
@@ -94,6 +94,7 @@ export class PredictionsService {
         fixture_id: fixtureId.toString(),
         choice,
         week: fixture.week || 1, // Assuming fixture has a week property
+        season: fixture.season, // Denormalized from the fixture (like week)
       });
 
       try {

--- a/apps/backend/gaming-services/src/modules/season/season-config.service.ts
+++ b/apps/backend/gaming-services/src/modules/season/season-config.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Single source of truth for the current Serie A season.
+ *
+ * The same value drives both API-FOOTBALL requests and DB season filters,
+ * so live/test data and stats never mix across seasons. Set via the
+ * CURRENT_SEASON env var (default 2025); flip to 2026 to switch the app to
+ * the 2026-2027 season once its calendar is imported.
+ */
+@Injectable()
+export class SeasonConfigService {
+  constructor(private readonly configService: ConfigService) {}
+
+  getCurrentSeason(): number {
+    return this.configService.get<number>('season.current', 2025);
+  }
+}

--- a/apps/backend/gaming-services/src/modules/season/season.module.ts
+++ b/apps/backend/gaming-services/src/modules/season/season.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { SeasonConfigService } from './season-config.service';
+
+/**
+ * Global so any service can inject SeasonConfigService without importing
+ * this module everywhere (pattern consistent with CacheServiceModule).
+ */
+@Global()
+@Module({
+  providers: [SeasonConfigService],
+  exports: [SeasonConfigService],
+})
+export class SeasonModule {}

--- a/apps/backend/gaming-services/src/modules/specs/specs.controller.ts
+++ b/apps/backend/gaming-services/src/modules/specs/specs.controller.ts
@@ -67,7 +67,10 @@ export class SpecsController {
     this.logger.debug(
       '🚀 [SPECS_CONTROLLER] *** UNIFIED PREDICTION ENDPOINT HIT ***',
     );
-    this.logger.debug('🚀 [SPECS_CONTROLLER] Timestamp:', new Date().toISOString());
+    this.logger.debug(
+      '🚀 [SPECS_CONTROLLER] Timestamp:',
+      new Date().toISOString(),
+    );
     this.logger.debug('🚀 [SPECS_CONTROLLER] Full request body received:');
     this.logger.debug('🚀 [SPECS_CONTROLLER] Raw object:', data);
     this.logger.debug(
@@ -175,10 +178,14 @@ export class SpecsController {
     @Param('userId') userId: string,
     @Param('week', ParseIntPipe) week: number,
     @Query('mode') mode?: 'live' | 'test',
+    @Query('season') season?: number,
   ): Promise<WeeklyStatsResponseDto> {
     this.logger.debug('🟡 [SPECS_CONTROLLER] ='.repeat(50));
     this.logger.debug('🟡 [SPECS_CONTROLLER] getWeeklyStats endpoint hit');
-    this.logger.debug('🟡 [SPECS_CONTROLLER] Timestamp:', new Date().toISOString());
+    this.logger.debug(
+      '🟡 [SPECS_CONTROLLER] Timestamp:',
+      new Date().toISOString(),
+    );
     this.logger.debug('🟡 [SPECS_CONTROLLER] Raw params received:');
     this.logger.debug('🟡 [SPECS_CONTROLLER] - userId:', {
       value: userId,
@@ -237,6 +244,7 @@ export class SpecsController {
         userId,
         week,
         'live',
+        season ? Number(season) : undefined,
       );
       this.logger.debug(
         '🟡 [SPECS_CONTROLLER] Live mode service completed successfully',
@@ -277,9 +285,14 @@ export class SpecsController {
   async getUserSummary(
     @Param('userId') userId: string,
     @Query('mode') mode?: 'live' | 'test',
+    @Query('season') season?: number,
   ): Promise<UserSummaryResponseDto> {
     const summaryMode = mode || 'live';
-    return this.specsService.getUserSummary(userId, summaryMode);
+    return this.specsService.getUserSummary(
+      userId,
+      summaryMode,
+      season ? Number(season) : undefined,
+    );
   }
 
   /**

--- a/apps/backend/gaming-services/src/modules/specs/specs.service.ts
+++ b/apps/backend/gaming-services/src/modules/specs/specs.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Spec } from '../../entities/spec.entity';
 import { Fixture } from '../../entities/fixture.entity';
+import { SeasonConfigService } from '../season/season-config.service';
 import {
   CreateSpecDto,
   SpecResponseDto,
@@ -24,6 +25,7 @@ export class SpecsService {
     private specRepository: Repository<Spec>,
     @InjectRepository(Fixture)
     private fixtureRepository: Repository<Fixture>,
+    private readonly seasonConfig: SeasonConfigService,
   ) {}
 
   async createPrediction(
@@ -67,6 +69,7 @@ export class SpecsService {
       );
       existingSpec.choice = choice;
       existingSpec.week = fixture.week; // Update week to match fixture if it was wrong
+      existingSpec.season = fixture.season;
       existingSpec.timestamp = new Date();
 
       const savedSpec = await this.specRepository.save(existingSpec);
@@ -84,11 +87,14 @@ export class SpecsService {
       fixture_id,
       choice,
       week: fixture.week, // Use the actual week from the fixture
+      season: fixture.season, // Denormalized from the fixture (like week)
       mode: 'live',
     });
 
     const savedSpec = await this.specRepository.save(spec);
-    this.logger.debug(`✅ [SPECS_SERVICE] Spec saved with week ${savedSpec.week}`);
+    this.logger.debug(
+      `✅ [SPECS_SERVICE] Spec saved with week ${savedSpec.week}`,
+    );
 
     // Return response with match display
     return this.mapSpecToResponse(savedSpec, fixture);
@@ -98,10 +104,15 @@ export class SpecsService {
     userId: string,
     week: number,
     mode: 'live' | 'test' = 'live',
+    season?: number,
   ): Promise<WeeklyStatsResponseDto> {
+    const targetSeason = season ?? this.seasonConfig.getCurrentSeason();
     this.logger.debug('🟢 [SPECS_SERVICE] ='.repeat(50));
     this.logger.debug('🟢 [SPECS_SERVICE] getWeeklyStats called');
-    this.logger.debug('🟢 [SPECS_SERVICE] Timestamp:', new Date().toISOString());
+    this.logger.debug(
+      '🟢 [SPECS_SERVICE] Timestamp:',
+      new Date().toISOString(),
+    );
     this.logger.debug('🟢 [SPECS_SERVICE] Parameters:');
     this.logger.debug('🟢 [SPECS_SERVICE] - userId:', {
       value: userId,
@@ -127,15 +138,17 @@ export class SpecsService {
         order: { timestamp: 'ASC' },
       });
 
-      // Get all predictions for the user in the specified week and mode
+      // Get all predictions for the user in the specified week, season and mode
       this.logger.debug('🟢 [SPECS_SERVICE] Executing database query...');
       const specs = await this.specRepository.find({
-        where: { user_id: userId, week, mode },
+        where: { user_id: userId, week, season: targetSeason, mode },
         relations: ['fixture'],
         order: { timestamp: 'ASC' },
       });
 
-      this.logger.debug('🟢 [SPECS_SERVICE] Database query completed successfully');
+      this.logger.debug(
+        '🟢 [SPECS_SERVICE] Database query completed successfully',
+      );
       this.logger.debug('🟢 [SPECS_SERVICE] Found specs count:', specs.length);
 
       if (specs.length > 0) {
@@ -212,10 +225,12 @@ export class SpecsService {
   async getUserSummary(
     userId: string,
     mode: 'live' | 'test' = 'live',
+    season?: number,
   ): Promise<UserSummaryResponseDto> {
-    // Get all predictions for the user in the specified mode
+    const targetSeason = season ?? this.seasonConfig.getCurrentSeason();
+    // Get all predictions for the user in the specified mode and season
     const allSpecs = await this.specRepository.find({
-      where: { user_id: userId, mode },
+      where: { user_id: userId, season: targetSeason, mode },
       relations: ['fixture'],
       order: { week: 'ASC', timestamp: 'ASC' },
     });
@@ -328,7 +343,11 @@ export class SpecsService {
     week?: number,
   ): Promise<number> {
     this.logger.debug('🗑️ [DELETE_PREDICTIONS] Delete request received');
-    this.logger.debug('🗑️ [DELETE_PREDICTIONS] Parameters:', { userId, mode, week });
+    this.logger.debug('🗑️ [DELETE_PREDICTIONS] Parameters:', {
+      userId,
+      mode,
+      week,
+    });
 
     const whereConditions: any = { user_id: userId };
 
@@ -340,7 +359,10 @@ export class SpecsService {
       whereConditions.week = week;
     }
 
-    this.logger.debug('🗑️ [DELETE_PREDICTIONS] Where conditions:', whereConditions);
+    this.logger.debug(
+      '🗑️ [DELETE_PREDICTIONS] Where conditions:',
+      whereConditions,
+    );
 
     // Check what exists before delete
     const existingSpecs = await this.specRepository.find({

--- a/apps/backend/gaming-services/src/scripts/check-fixtures-integrity.ts
+++ b/apps/backend/gaming-services/src/scripts/check-fixtures-integrity.ts
@@ -44,7 +44,9 @@ async function main(): Promise<void> {
   );
 
   console.log('week | partite | mancanti | senza_risultato | giorni | range');
-  console.log('-----|---------|----------|-----------------|--------|------------------');
+  console.log(
+    '-----|---------|----------|-----------------|--------|------------------',
+  );
   for (const r of reports) {
     const range =
       r.firstMatch && r.lastMatch

--- a/apps/backend/gaming-services/src/scripts/import-season-fixtures.ts
+++ b/apps/backend/gaming-services/src/scripts/import-season-fixtures.ts
@@ -1,0 +1,205 @@
+/**
+ * Import a full Serie A season calendar into the `fixtures` table (INSERT).
+ *
+ * Unlike resync-season-fixtures.ts (which UPDATEs existing rows in place to
+ * refresh results), this inserts a brand-new season with `season = <year>`,
+ * preserving any other season already present. Idempotent: refuses to run if
+ * the season already has fixtures (unless --force), and inserts inside a
+ * transaction.
+ *
+ * Uso:
+ *   npx ts-node src/scripts/import-season-fixtures.ts --season 2026          # dry-run
+ *   npx ts-node src/scripts/import-season-fixtures.ts --season 2026 --apply  # scrive
+ *
+ * Richiede DATABASE_URL e API_FOOTBALL_KEY nell'ambiente (.env root monorepo).
+ */
+import { DataSource } from 'typeorm';
+import axios from 'axios';
+import { config } from 'dotenv';
+import { resolve } from 'path';
+
+config({ path: resolve(__dirname, '../../../../../.env') });
+config();
+
+const LEAGUE_ID = 135; // Serie A
+
+interface ApiFixture {
+  fixture: {
+    id: number;
+    date: string;
+    venue: { name: string | null };
+    status: { short: string };
+  };
+  league: { round: string };
+  teams: {
+    home: { id: number; name: string };
+    away: { id: number; name: string };
+  };
+  goals: { home: number | null; away: number | null };
+}
+
+const FINISHED = new Set(['FT', 'AET', 'PEN']);
+const LIVE = new Set(['1H', 'HT', '2H', 'ET', 'BT', 'P', 'LIVE']);
+
+const mapStatus = (short: string): string => {
+  if (FINISHED.has(short)) return 'FINISHED';
+  if (LIVE.has(short)) return 'LIVE';
+  if (short === 'PST') return 'POSTPONED';
+  if (short === 'CANC') return 'CANCELLED';
+  return 'SCHEDULED';
+};
+
+const computeResult = (
+  home: number | null,
+  away: number | null,
+): string | null => {
+  if (home === null || away === null) return null;
+  if (home > away) return '1';
+  if (home < away) return '2';
+  return 'X';
+};
+
+const weekFromRound = (round: string): number => {
+  const m = round.match(/(\d+)$/);
+  return m ? parseInt(m[1], 10) : 1;
+};
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const apply = args.includes('--apply');
+  const force = args.includes('--force');
+  const seasonArg = args[args.indexOf('--season') + 1];
+  const season = seasonArg ? parseInt(seasonArg, 10) : NaN;
+
+  if (Number.isNaN(season)) {
+    console.error('Specificare --season <anno>, es: --season 2026');
+    process.exit(1);
+  }
+
+  const apiKey = process.env.API_FOOTBALL_KEY;
+  if (!apiKey || !process.env.DATABASE_URL) {
+    console.error("API_FOOTBALL_KEY o DATABASE_URL mancanti nell'ambiente");
+    process.exit(1);
+  }
+
+  console.log(
+    `Modalità: ${apply ? '✍️  APPLY (scrive sul DB)' : '👀 DRY-RUN (nessuna scrittura)'}`,
+  );
+  console.log(`Stagione da importare: ${season}\n`);
+
+  const dataSource = new DataSource({
+    type: 'postgres',
+    url: process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: true }, // Verify Neon certificate (public CA)
+  });
+  await dataSource.initialize();
+
+  // Idempotency guard: refuse if the season already exists.
+  const existing: Array<{ count: string }> = await dataSource.query(
+    'SELECT COUNT(*)::text AS count FROM fixtures WHERE season = $1',
+    [season],
+  );
+  const existingCount = parseInt(existing[0]?.count ?? '0', 10);
+  if (existingCount > 0 && !force) {
+    console.error(
+      `⚠️  La stagione ${season} ha già ${existingCount} fixture nel DB. Usa --force per reimportare.`,
+    );
+    await dataSource.destroy();
+    process.exit(1);
+  }
+
+  console.log(`📡 Fetching Serie A ${season} fixtures da API-Football...`);
+  const { data } = await axios.get(
+    'https://v3.football.api-sports.io/fixtures',
+    {
+      headers: {
+        'X-RapidAPI-Key': apiKey,
+        'X-RapidAPI-Host': 'v3.football.api-sports.io',
+      },
+      params: { league: LEAGUE_ID, season },
+    },
+  );
+  const apiFixtures: ApiFixture[] = data.response ?? [];
+  console.log(`✅ Ricevute ${apiFixtures.length} partite da API\n`);
+
+  if (apiFixtures.length === 0) {
+    console.error('Nessuna partita restituita — abort.');
+    await dataSource.destroy();
+    process.exit(1);
+  }
+
+  const rows = apiFixtures.map((api) => ({
+    home_team: api.teams.home.name,
+    away_team: api.teams.away.name,
+    match_date: new Date(api.fixture.date),
+    stadium: api.fixture.venue?.name ?? 'TBD',
+    week: weekFromRound(api.league.round),
+    season,
+    status: mapStatus(api.fixture.status.short),
+    result:
+      mapStatus(api.fixture.status.short) === 'FINISHED'
+        ? computeResult(api.goals.home, api.goals.away)
+        : null,
+    home_score: api.goals.home,
+    away_score: api.goals.away,
+    external_api_id: `api_football_${api.fixture.id}`,
+  }));
+
+  const byWeek = rows.reduce<Record<number, number>>((acc, r) => {
+    acc[r.week] = (acc[r.week] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log(
+    `Riepilogo: ${rows.length} partite, ${Object.keys(byWeek).length} giornate distinte.`,
+  );
+
+  if (!apply) {
+    console.log(
+      '\n👀 DRY-RUN: nessuna scrittura. Rilanciare con --apply per importare.',
+    );
+    await dataSource.destroy();
+    return;
+  }
+
+  const queryRunner = dataSource.createQueryRunner();
+  await queryRunner.connect();
+  await queryRunner.startTransaction();
+  try {
+    for (const r of rows) {
+      await queryRunner.query(
+        `INSERT INTO fixtures
+           (home_team, away_team, match_date, stadium, week, season, status, result, home_score, away_score, external_api_id, created_at, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, NOW(), NOW())`,
+        [
+          r.home_team,
+          r.away_team,
+          r.match_date,
+          r.stadium,
+          r.week,
+          r.season,
+          r.status,
+          r.result,
+          r.home_score,
+          r.away_score,
+          r.external_api_id,
+        ],
+      );
+    }
+    await queryRunner.commitTransaction();
+    console.log(
+      `\n✍️  Inserite ${rows.length} fixture per la stagione ${season}.`,
+    );
+  } catch (err) {
+    await queryRunner.rollbackTransaction();
+    console.error('Import fallito, rollback eseguito:', (err as Error).message);
+    process.exitCode = 1;
+  } finally {
+    await queryRunner.release();
+    await dataSource.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error('Import failed:', err.message);
+  process.exit(1);
+});

--- a/apps/backend/gaming-services/src/scripts/resync-season-fixtures.ts
+++ b/apps/backend/gaming-services/src/scripts/resync-season-fixtures.ts
@@ -29,7 +29,10 @@ interface ApiFixture {
     venue: { name: string | null };
     status: { short: string };
   };
-  teams: { home: { id: number; name: string }; away: { id: number; name: string } };
+  teams: {
+    home: { id: number; name: string };
+    away: { id: number; name: string };
+  };
   goals: { home: number | null; away: number | null };
 }
 
@@ -65,7 +68,10 @@ const mapStatus = (short: string): string => {
   return 'SCHEDULED';
 };
 
-const computeResult = (home: number | null, away: number | null): string | null => {
+const computeResult = (
+  home: number | null,
+  away: number | null,
+): string | null => {
   if (home === null || away === null) return null;
   if (home > away) return '1';
   if (home < away) return '2';
@@ -78,17 +84,21 @@ async function main(): Promise<void> {
   const weeks = args.filter((a) => /^\d+$/.test(a)).map(Number);
 
   if (weeks.length === 0) {
-    console.error('Specificare almeno una giornata, es: resync-season-fixtures.ts 35 36');
+    console.error(
+      'Specificare almeno una giornata, es: resync-season-fixtures.ts 35 36',
+    );
     process.exit(1);
   }
 
   const apiKey = process.env.API_FOOTBALL_KEY;
   if (!apiKey || !process.env.DATABASE_URL) {
-    console.error('API_FOOTBALL_KEY o DATABASE_URL mancanti nell\'ambiente');
+    console.error("API_FOOTBALL_KEY o DATABASE_URL mancanti nell'ambiente");
     process.exit(1);
   }
 
-  console.log(`Modalità: ${apply ? '✍️  APPLY (scrive sul DB)' : '👀 DRY-RUN (nessuna scrittura)'}`);
+  console.log(
+    `Modalità: ${apply ? '✍️  APPLY (scrive sul DB)' : '👀 DRY-RUN (nessuna scrittura)'}`,
+  );
   console.log(`Stagione: ${SEASON} — Giornate: ${weeks.join(', ')}\n`);
 
   const dataSource = new DataSource({
@@ -104,10 +114,16 @@ async function main(): Promise<void> {
 
   for (const week of weeks) {
     const round = `Regular Season - ${week}`;
-    const { data } = await axios.get('https://v3.football.api-sports.io/fixtures', {
-      headers: { 'X-RapidAPI-Key': apiKey, 'X-RapidAPI-Host': 'v3.football.api-sports.io' },
-      params: { league: LEAGUE_ID, season: SEASON, round },
-    });
+    const { data } = await axios.get(
+      'https://v3.football.api-sports.io/fixtures',
+      {
+        headers: {
+          'X-RapidAPI-Key': apiKey,
+          'X-RapidAPI-Host': 'v3.football.api-sports.io',
+        },
+        params: { league: LEAGUE_ID, season: SEASON, round },
+      },
+    );
 
     const apiFixtures: ApiFixture[] = data.response ?? [];
     console.log(`— Giornata ${week}: ${apiFixtures.length} partite da API`);
@@ -129,29 +145,43 @@ async function main(): Promise<void> {
         );
 
       if (!db) {
-        unmatched.push(`g.${week}: ${api.teams.home.name} vs ${api.teams.away.name}`);
+        unmatched.push(
+          `g.${week}: ${api.teams.home.name} vs ${api.teams.away.name}`,
+        );
         continue;
       }
 
       const newStatus = mapStatus(api.fixture.status.short);
-      const newResult = newStatus === 'FINISHED' ? computeResult(api.goals.home, api.goals.away) : db.result;
+      const newResult =
+        newStatus === 'FINISHED'
+          ? computeResult(api.goals.home, api.goals.away)
+          : db.result;
       const newDate = new Date(api.fixture.date);
 
       const changes: string[] = [];
       if (new Date(db.match_date).getTime() !== newDate.getTime())
-        changes.push(`date ${new Date(db.match_date).toISOString().slice(0, 16)} → ${newDate.toISOString().slice(0, 16)}`);
-      if (db.status !== newStatus) changes.push(`status ${db.status} → ${newStatus}`);
+        changes.push(
+          `date ${new Date(db.match_date).toISOString().slice(0, 16)} → ${newDate.toISOString().slice(0, 16)}`,
+        );
+      if (db.status !== newStatus)
+        changes.push(`status ${db.status} → ${newStatus}`);
       if (db.home_score !== api.goals.home || db.away_score !== api.goals.away)
-        changes.push(`score ${db.home_score ?? '-'}–${db.away_score ?? '-'} → ${api.goals.home ?? '-'}–${api.goals.away ?? '-'}`);
-      if (db.result !== newResult) changes.push(`result ${db.result ?? '-'} → ${newResult ?? '-'}`);
-      if (db.external_api_id !== apiId) changes.push(`external_api_id → ${apiId}`);
+        changes.push(
+          `score ${db.home_score ?? '-'}–${db.away_score ?? '-'} → ${api.goals.home ?? '-'}–${api.goals.away ?? '-'}`,
+        );
+      if (db.result !== newResult)
+        changes.push(`result ${db.result ?? '-'} → ${newResult ?? '-'}`);
+      if (db.external_api_id !== apiId)
+        changes.push(`external_api_id → ${apiId}`);
 
       if (changes.length === 0) {
         unchanged++;
         continue;
       }
 
-      console.log(`  ${db.home_team} vs ${db.away_team}: ${changes.join(', ')}`);
+      console.log(
+        `  ${db.home_team} vs ${db.away_team}: ${changes.join(', ')}`,
+      );
       updated++;
 
       if (apply) {
@@ -160,18 +190,32 @@ async function main(): Promise<void> {
            SET match_date = $1, status = $2, home_score = $3, away_score = $4,
                result = $5, external_api_id = $6, updated_at = NOW()
            WHERE id = $7`,
-          [newDate, newStatus, api.goals.home, api.goals.away, newResult, apiId, db.id],
+          [
+            newDate,
+            newStatus,
+            api.goals.home,
+            api.goals.away,
+            newResult,
+            apiId,
+            db.id,
+          ],
         );
       }
     }
   }
 
-  console.log(`\n${apply ? 'Aggiornate' : 'Da aggiornare'}: ${updated} — Già corrette: ${unchanged}`);
+  console.log(
+    `\n${apply ? 'Aggiornate' : 'Da aggiornare'}: ${updated} — Già corrette: ${unchanged}`,
+  );
   if (unmatched.length > 0) {
-    console.log(`⚠️  Non abbinate (nessuna modifica): \n  ${unmatched.join('\n  ')}`);
+    console.log(
+      `⚠️  Non abbinate (nessuna modifica): \n  ${unmatched.join('\n  ')}`,
+    );
   }
   if (!apply && updated > 0) {
-    console.log('\nNessuna scrittura effettuata. Rilanciare con --apply per applicare.');
+    console.log(
+      '\nNessuna scrittura effettuata. Rilanciare con --apply per applicare.',
+    );
   }
 
   await dataSource.destroy();


### PR DESCRIPTION
## Cosa

Introduce la dimensione **stagione** nel modello dati di `gaming-services` per ospitare il calendario 2026-27 preservando lo storico 2025.

- Colonna `season` (DEFAULT 2025) su `fixtures`/`specs`/`final_week_scores` via migration `AddSeasonColumns`; unique di `final_week_scores` allargata a `[userId, week, season, mode]`; backfill specs da `fixture.season`.
- `CURRENT_SEASON` configurabile via `season.config` + `SeasonConfigService` globale, al posto degli hardcoded 2025.
- Query season-aware: fixtures-by-week, next/live, polling date-range, stats su specs, stats/classifica final-week-scores (solo ramo live; tabelle test invariate).
- Nuovo `getLastPlayedWeek()` + `GET /fixtures/last-played` per init Risultati.
- Script `import-season-fixtures.ts` (INSERT, dry-run default, idempotente).
- Endpoint di lettura accettano `?season=` opzionale.
- Test: `fixtures.service.spec`, `final-week-scores.season.spec`.

## Sicurezza rollout

Con `CURRENT_SEASON=2025` il comportamento è **identico a oggi** (passo di rollout sicuro). La migration è già stata applicata in prod (DEFAULT 2025 mantiene compatibile il codice precedente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)