### PR TITLE
Test mode: sequential per-user giornata progression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage/
 
 # macOS
 .DS_Store
+
+# Local DB backups (contain production data dumps — never commit)
+db-backups/

--- a/apps/backend/bff/src/app.controller.ts
+++ b/apps/backend/bff/src/app.controller.ts
@@ -261,6 +261,24 @@ export class AppController {
     );
   }
 
+  // Test Mode sequential giornata progression
+  @Get('api/test-mode/progression/:userId')
+  async getTestProgression(@Param('userId') userId: string) {
+    this.logger.log(`Getting test progression for user ${userId}`);
+    return this.appService.forwardToGamingServices(
+      `/api/test-mode/progression/${userId}`,
+    );
+  }
+
+  @Post('api/test-mode/progression/:userId/next')
+  async advanceTestProgression(@Param('userId') userId: string) {
+    this.logger.log(`Advancing test progression for user ${userId}`);
+    return this.appService.forwardToGamingServices(
+      `/api/test-mode/progression/${userId}/next`,
+      'POST',
+    );
+  }
+
   // Match Cards Endpoints
   @Get('api/match-cards/week/:weekNumber')
   async getMatchCardsByWeek(

--- a/apps/backend/gaming-services/src/config/database.config.ts
+++ b/apps/backend/gaming-services/src/config/database.config.ts
@@ -4,6 +4,7 @@ import { Fixture } from '../entities/fixture.entity';
 import { Spec } from '../entities/spec.entity';
 import { TestFixture } from '../entities/test-fixture.entity';
 import { TestSpec } from '../entities/test-spec.entity';
+import { TestUserProgress } from '../entities/test-user-progress.entity';
 import { FinalWeekScore } from '../entities/final-week-score.entity';
 
 export const DatabaseConfig = registerAs(
@@ -14,7 +15,14 @@ export const DatabaseConfig = registerAs(
       return {
         type: 'postgres',
         url: process.env.DATABASE_URL,
-        entities: [Fixture, Spec, TestFixture, TestSpec, FinalWeekScore],
+        entities: [
+          Fixture,
+          Spec,
+          TestFixture,
+          TestSpec,
+          TestUserProgress,
+          FinalWeekScore,
+        ],
         migrations: [__dirname + '/../database/migrations/*{.ts,.js}'],
         synchronize: false, // Disabled for local builds
         logging: process.env.NODE_ENV === 'development',

--- a/apps/backend/gaming-services/src/database/migrations/1761000000000-CreateTestUserProgress.ts
+++ b/apps/backend/gaming-services/src/database/migrations/1761000000000-CreateTestUserProgress.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates `test_user_progress`: a per-user sequential giornata pointer for the
+ * isolated TEST mode. One row per user, `currentWeek` defaults to 1 and is
+ * advanced explicitly via the "Prossima giornata" action.
+ */
+export class CreateTestUserProgress1761000000000 implements MigrationInterface {
+  name = 'CreateTestUserProgress1761000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "test_user_progress" (
+        "userId" varchar(64) NOT NULL,
+        "currentWeek" integer NOT NULL DEFAULT 1,
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_test_user_progress" PRIMARY KEY ("userId")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "test_user_progress"`);
+  }
+}

--- a/apps/backend/gaming-services/src/entities/test-user-progress.entity.ts
+++ b/apps/backend/gaming-services/src/entities/test-user-progress.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryColumn, Column, UpdateDateColumn } from 'typeorm';
+
+/**
+ * Per-user sequential progression pointer for TEST mode.
+ *
+ * Test mode uses a frozen 2023-24 dataset (all fixtures FINISHED), so there is
+ * no real-time clock. Instead each user advances giornata-by-giornata via an
+ * explicit "Prossima giornata" action. `currentWeek` is the giornata currently
+ * playable in Gioca; Risultati can always inspect weeks 1..currentWeek with
+ * their (already known) results. Fully isolated from live data.
+ */
+@Entity('test_user_progress')
+export class TestUserProgress {
+  @PrimaryColumn({ type: 'varchar', length: 64 })
+  userId: string;
+
+  @Column({ type: 'integer', default: 1 })
+  currentWeek: number;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/gaming-services/src/modules/test-mode/test-mode.controller.ts
+++ b/apps/backend/gaming-services/src/modules/test-mode/test-mode.controller.ts
@@ -132,6 +132,32 @@ export class TestModeController {
     };
   }
 
+  @Get('progression/:userId')
+  async getProgression(@Param('userId') userId: string) {
+    this.logger.log(`Getting test progression for user ${userId}`);
+
+    const progression = await this.testModeService.getProgression(userId);
+
+    return {
+      success: true,
+      data: progression,
+      message: `Test progression retrieved for user ${userId}`,
+    };
+  }
+
+  @Post('progression/:userId/next')
+  async advanceProgression(@Param('userId') userId: string) {
+    this.logger.log(`Advancing test progression for user ${userId}`);
+
+    const progression = await this.testModeService.advanceProgression(userId);
+
+    return {
+      success: true,
+      data: progression,
+      message: `Advanced to test giornata ${progression.currentWeek}`,
+    };
+  }
+
   @Post('seed')
   async seedTestData(@Query('force') force?: string) {
     const forceReplace = force === 'true' || force === '1';

--- a/apps/backend/gaming-services/src/modules/test-mode/test-mode.module.ts
+++ b/apps/backend/gaming-services/src/modules/test-mode/test-mode.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { TestFixture } from '../../entities/test-fixture.entity';
 import { TestSpec } from '../../entities/test-spec.entity';
+import { TestUserProgress } from '../../entities/test-user-progress.entity';
 import { FinalWeekScore } from '../../entities/final-week-score.entity';
 import { TestModeService } from './test-mode.service';
 import { TestModeController } from './test-mode.controller';
@@ -9,7 +10,12 @@ import { ApiFootballModule } from '../api-football/api-football.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([TestFixture, TestSpec, FinalWeekScore]),
+    TypeOrmModule.forFeature([
+      TestFixture,
+      TestSpec,
+      TestUserProgress,
+      FinalWeekScore,
+    ]),
     ApiFootballModule,
   ],
   controllers: [TestModeController],

--- a/apps/backend/gaming-services/src/modules/test-mode/test-mode.progression.spec.ts
+++ b/apps/backend/gaming-services/src/modules/test-mode/test-mode.progression.spec.ts
@@ -1,0 +1,83 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TestModeService } from './test-mode.service';
+import { TestFixture } from '../../entities/test-fixture.entity';
+import { TestSpec } from '../../entities/test-spec.entity';
+import { TestUserProgress } from '../../entities/test-user-progress.entity';
+import { FinalWeekScore } from '../../entities/final-week-score.entity';
+import { ApiFootballService } from '../api-football/api-football.service';
+
+/**
+ * Sequential giornata progression for test mode: starts at 1, advances one
+ * giornata at a time, and never exceeds the last available test giornata.
+ */
+describe('TestModeService — progression', () => {
+  let service: TestModeService;
+  let progressRow: { userId: string; currentWeek: number } | null;
+
+  const maxWeekQB = {
+    select: jest.fn().mockReturnThis(),
+    getRawOne: jest.fn().mockResolvedValue({ max: '38' }),
+  };
+
+  const testFixtureRepository = {
+    createQueryBuilder: jest.fn(() => maxWeekQB),
+  };
+
+  const testUserProgressRepository = {
+    findOne: jest.fn(async () => progressRow),
+    create: jest.fn((row) => row),
+    save: jest.fn(async (row) => {
+      progressRow = row;
+      return row;
+    }),
+    update: jest.fn(async (_where, patch) => {
+      if (progressRow) Object.assign(progressRow, patch);
+      return { affected: 1 };
+    }),
+    upsert: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    progressRow = null;
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TestModeService,
+        { provide: getRepositoryToken(TestFixture), useValue: testFixtureRepository },
+        { provide: getRepositoryToken(TestSpec), useValue: {} },
+        { provide: getRepositoryToken(TestUserProgress), useValue: testUserProgressRepository },
+        { provide: getRepositoryToken(FinalWeekScore), useValue: {} },
+        { provide: ApiFootballService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<TestModeService>(TestModeService);
+  });
+
+  it('creates progression at giornata 1 on first access', async () => {
+    const res = await service.getProgression('user-1');
+    expect(res.currentWeek).toBe(1);
+    expect(res.maxWeek).toBe(38);
+    expect(res.playedWeeks).toEqual([1]);
+    expect(testUserProgressRepository.save).toHaveBeenCalled();
+  });
+
+  it('advances one giornata at a time, in sequence', async () => {
+    await service.getProgression('user-1'); // seeds at 1
+    const a = await service.advanceProgression('user-1');
+    expect(a.currentWeek).toBe(2);
+    expect(a.playedWeeks).toEqual([1, 2]);
+
+    const b = await service.advanceProgression('user-1');
+    expect(b.currentWeek).toBe(3);
+  });
+
+  it('never advances past the last available giornata (maxWeek)', async () => {
+    progressRow = { userId: 'user-1', currentWeek: 38 };
+    const res = await service.advanceProgression('user-1');
+    expect(res.currentWeek).toBe(38);
+    expect(testUserProgressRepository.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/gaming-services/src/modules/test-mode/test-mode.service.ts
+++ b/apps/backend/gaming-services/src/modules/test-mode/test-mode.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TestFixture } from '../../entities/test-fixture.entity';
 import { TestSpec } from '../../entities/test-spec.entity';
+import { TestUserProgress } from '../../entities/test-user-progress.entity';
 import { FinalWeekScore } from '../../entities/final-week-score.entity';
 import { ApiFootballService } from '../api-football/api-football.service';
 import { WeeklyStats, UserSummary } from './dto/test-mode.dto';
@@ -39,6 +40,8 @@ export class TestModeService {
     private testFixtureRepository: Repository<TestFixture>,
     @InjectRepository(TestSpec)
     private testSpecRepository: Repository<TestSpec>,
+    @InjectRepository(TestUserProgress)
+    private testUserProgressRepository: Repository<TestUserProgress>,
     @InjectRepository(FinalWeekScore)
     private finalWeekScoreRepository: Repository<FinalWeekScore>,
     private readonly apiFootballService: ApiFootballService,
@@ -67,8 +70,10 @@ export class TestModeService {
 
     const cards: MatchCardDto[] = [];
 
-    // Auto-complete past fixtures based on virtual time before computing stats
-    await this.autoCompleteVirtualFixtures();
+    // NOTE: the legacy real-time "virtual clock" auto-completion was removed.
+    // The test dataset (2023-24) is fully FINISHED with results, and giornata
+    // progression is now driven explicitly per-user (see getProgression /
+    // advanceProgression), not by elapsed wall-clock time.
 
     // Preload prior fixtures up to week-1 to compute stats in-memory
     const priorFixtures = isWeekOne
@@ -1273,8 +1278,13 @@ export class TestModeService {
       mode: 'test',
     });
 
+    // Reset the sequential giornata pointer back to week 1
+    await this.testUserProgressRepository.upsert({ userId, currentWeek: 1 }, [
+      'userId',
+    ]);
+
     this.logger.log(
-      `✅ Test data reset completed for user ${userId}: ${deleteResult.affected || 0} predictions deleted, ${finalScoresDeleteResult.affected || 0} final week scores deleted`,
+      `✅ Test data reset completed for user ${userId}: ${deleteResult.affected || 0} predictions deleted, ${finalScoresDeleteResult.affected || 0} final week scores deleted, progression reset to week 1`,
     );
 
     // Invalidate all cache entries for this user across weeks
@@ -1294,73 +1304,72 @@ export class TestModeService {
     }
   }
 
+  // --- Sequential giornata progression (test mode) ---
+
   /**
-   * Auto-complete fixtures that have passed in virtual time with their predefined scores
-   * This enables historical last5 calculations for test mode
+   * Return the user's progression pointer for test mode, creating it at week 1
+   * on first access. `playedWeeks` are the giornate reached so far (1..current)
+   * and are always inspectable in Risultati with their known results.
    */
-  private async autoCompleteVirtualFixtures(): Promise<void> {
-    // Get current virtual time (September 9, 2023 13:35 + elapsed time)
-    const virtualStartDate = new Date('2023-09-09T13:35:00.000Z');
-    const realElapsed = Date.now() - virtualStartDate.getTime();
+  async getProgression(
+    userId: string,
+  ): Promise<{ currentWeek: number; playedWeeks: number[]; maxWeek: number }> {
+    const maxWeek = await this.getMaxTestWeek();
 
-    // For demo purposes, simulate that time passes quickly in virtual mode
-    const virtualNow = new Date(virtualStartDate.getTime() + realElapsed);
-
-    this.logger.log(`[AutoComplete] Virtual time: ${virtualNow.toISOString()}`);
-
-    // Find fixtures that should be completed (date has passed) but don't have scores yet
-    const fixturesToComplete = await this.testFixtureRepository
-      .createQueryBuilder('fixture')
-      .where('fixture.date < :virtualNow', { virtualNow })
-      .andWhere('fixture.homeScore IS NULL OR fixture.awayScore IS NULL')
-      .getMany();
-
-    if (fixturesToComplete.length === 0) {
-      return; // Nothing to complete
+    let progress = await this.testUserProgressRepository.findOne({
+      where: { userId },
+    });
+    if (!progress) {
+      progress = this.testUserProgressRepository.create({
+        userId,
+        currentWeek: 1,
+      });
+      await this.testUserProgressRepository.save(progress);
     }
 
-    this.logger.log(
-      `[AutoComplete] Found ${fixturesToComplete.length} fixtures to complete`,
-    );
+    // Clamp defensively in case the dataset shrank below a stored pointer.
+    const currentWeek = Math.min(Math.max(progress.currentWeek, 1), maxWeek);
+    const playedWeeks = Array.from({ length: currentWeek }, (_, i) => i + 1);
 
-    // Complete each fixture with its predefined scores from the seed data
-    for (const fixture of fixturesToComplete) {
-      // Set scores from the original seed data structure
-      const completed = this.getCompletedFixtureScores(fixture);
-      if (completed) {
-        await this.testFixtureRepository.update(
-          { id: fixture.id },
-          { homeScore: completed.homeScore, awayScore: completed.awayScore },
-        );
-        this.logger.log(
-          `[AutoComplete] Completed fixture ${fixture.id}: ${fixture.homeTeam} ${completed.homeScore}-${completed.awayScore} ${fixture.awayTeam}`,
-        );
-      }
-    }
+    return { currentWeek, playedWeeks, maxWeek };
   }
 
   /**
-   * Get the predefined scores for a fixture based on the original seed data
+   * Advance the user's giornata pointer by one ("Prossima giornata"), capped at
+   * the last available test giornata. Free advance — no requirement to have
+   * completed the current giornata's predictions.
    */
-  private getCompletedFixtureScores(
-    fixture: TestFixture,
-  ): { homeScore: number; awayScore: number } | null {
-    // This maps to the predefined results from the seed data
-    const results: Record<string, { homeScore: number; awayScore: number }> = {
-      // Week 1 results
-      'Genoa-Fiorentina': { homeScore: 1, awayScore: 4 },
-      'Inter-Monza': { homeScore: 2, awayScore: 0 },
-      'Empoli-Verona': { homeScore: 0, awayScore: 1 },
-      'Frosinone-Napoli': { homeScore: 1, awayScore: 3 },
-      'Lecce-Lazio': { homeScore: 2, awayScore: 1 },
-      'Udinese-Juventus': { homeScore: 0, awayScore: 3 },
-      'AS Roma-Salernitana': { homeScore: 2, awayScore: 1 },
-      'Sassuolo-Cagliari': { homeScore: 2, awayScore: 1 },
-      'Bologna-AC Milan': { homeScore: 0, awayScore: 2 },
-      'Torino-Atalanta': { homeScore: 1, awayScore: 2 },
-    };
+  async advanceProgression(
+    userId: string,
+  ): Promise<{ currentWeek: number; playedWeeks: number[]; maxWeek: number }> {
+    const { currentWeek, maxWeek } = await this.getProgression(userId);
+    const nextWeek = Math.min(currentWeek + 1, maxWeek);
 
-    const key = `${fixture.homeTeam}-${fixture.awayTeam}`;
-    return results[key] || null;
+    if (nextWeek !== currentWeek) {
+      await this.testUserProgressRepository.update(
+        { userId },
+        { currentWeek: nextWeek },
+      );
+      this.logger.log(
+        `[Progression] User ${userId} advanced to test giornata ${nextWeek}`,
+      );
+    } else {
+      this.logger.log(
+        `[Progression] User ${userId} already at last giornata ${maxWeek}`,
+      );
+    }
+
+    const playedWeeks = Array.from({ length: nextWeek }, (_, i) => i + 1);
+    return { currentWeek: nextWeek, playedWeeks, maxWeek };
+  }
+
+  /** Highest giornata available in the test dataset (fallback 38). */
+  private async getMaxTestWeek(): Promise<number> {
+    const row = await this.testFixtureRepository
+      .createQueryBuilder('fixture')
+      .select('MAX(fixture.week)', 'max')
+      .getRawOne<{ max: string | null }>();
+    const max = row?.max ? parseInt(row.max, 10) : 0;
+    return max > 0 ? max : 38;
   }
 }

--- a/apps/frontend/frontend-service/app/gioca/components/GameHeader/TestGameHeader.tsx
+++ b/apps/frontend/frontend-service/app/gioca/components/GameHeader/TestGameHeader.tsx
@@ -9,7 +9,7 @@ import { MdOutlineIosShare } from 'react-icons/md';
 import { CountdownTimer } from './CountdownTimer';
 import { ProgressBar } from './ProgressBar';
 import { useVirtualClock } from '../VirtualClock';
-import { calculateActiveWeek, getWeekFixtures, WeekInfo } from '../../utils/weekCalculator';
+import { getWeekFixtures, WeekInfo } from '../../utils/weekCalculator';
 import type { TimeToMatch } from '../../types';
 import { GAME_CONFIG } from '../../utils/constants';
 import { apiClient } from "@/lib/api-client";
@@ -41,8 +41,9 @@ export function TestGameHeader({
 }: TestGameHeaderProps) {
   const headerRef = useRef<HTMLDivElement | null>(null);
 
-  // Virtual clock for dynamic test time progression
-  const { virtualTime, formatDisplay, resetClock } = useVirtualClock();
+  // Virtual clock retained only for the cosmetic countdown timer; giornata
+  // selection is now driven by server-side sequential progression.
+  const { virtualTime, resetClock } = useVirtualClock();
 
   // Dynamic active week state - start with null to prevent showing incorrect week
   const [activeWeekInfo, setActiveWeekInfo] = useState<WeekInfo | null>(null);
@@ -50,6 +51,11 @@ export function TestGameHeader({
 
   // Virtual timeToMatch state for test mode
   const [virtualTimeToMatch, setVirtualTimeToMatch] = useState({ days: 0, hours: 0, minutes: 0, seconds: 0 });
+
+  // Sequential progression state (server-driven, replaces the virtual clock)
+  const [maxWeek, setMaxWeek] = useState<number>(38);
+  const [advanceLoading, setAdvanceLoading] = useState(false);
+  const [progressionTick, setProgressionTick] = useState(0);
 
   // Reset state
   const [isResetting, setIsResetting] = useState(false);
@@ -117,29 +123,63 @@ export function TestGameHeader({
     return () => window.removeEventListener('resize', measure);
   }, [onHeightChange]);
 
-  // Calculate active week and fetch fixtures based on virtual time
+  // Determine the active giornata from the server-side per-user progression
+  // (sequential, explicit "Prossima giornata" advance — no virtual clock).
   useEffect(() => {
+    if (!userKey) return;
     const updateActiveWeek = async () => {
       try {
-        // Calculate which week should be active for predictions
-        const weekInfo = await calculateActiveWeek(virtualTime);
+        const resp = await apiClient.getTestProgression(userKey);
+        const data = (resp as { data?: { currentWeek?: number; maxWeek?: number } })?.data ?? resp;
+        const currentWeek = Number((data as { currentWeek?: number })?.currentWeek ?? 1);
+        const max = Number((data as { maxWeek?: number })?.maxWeek ?? 38);
+        setMaxWeek(max);
+
+        const weekInfo: WeekInfo = { activeWeek: currentWeek, status: 'prediction' };
         setActiveWeekInfo(weekInfo);
 
         // Notify parent component of active week change
-        onActiveWeekChange?.(weekInfo.activeWeek);
+        onActiveWeekChange?.(currentWeek);
 
-        // Fetch fixtures for the active week
-        const fixtures = await getWeekFixtures(weekInfo.activeWeek);
+        // Fetch fixtures for the active week (date-range display)
+        const fixtures = await getWeekFixtures(currentWeek);
         setActiveWeekFixtures(fixtures);
 
-        console.log(`[TestGameHeader] Active week updated: ${weekInfo.activeWeek}, status: ${weekInfo.status}`);
+        console.log(`[TestGameHeader] Active giornata (progression): ${currentWeek}/${max}`);
       } catch (error) {
-        console.error('[TestGameHeader] Error in updateActiveWeek:', error);
+        console.error('[TestGameHeader] Error loading progression:', error);
       }
     };
 
     updateActiveWeek();
-  }, [virtualTime, onActiveWeekChange]); // Recalculate when virtual time changes
+  }, [userKey, onActiveWeekChange, progressionTick]); // Reload after advance/reset
+
+  // Advance to the next giornata in sequence ("Prossima giornata")
+  const handleNextGiornata = useCallback(async () => {
+    if (!userKey || advanceLoading) return;
+    try {
+      setAdvanceLoading(true);
+      // Clear local prediction flags so the new giornata starts fresh in the UI
+      try {
+        const keysToRemove: string[] = [];
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key && key.includes('swipick:gioca:') && key.includes(`:user:${userKey}`)) {
+            keysToRemove.push(key);
+          }
+        }
+        keysToRemove.forEach((k) => localStorage.removeItem(k));
+      } catch {}
+
+      await apiClient.advanceTestProgression(userKey);
+      onReset?.(); // reset local game state for the new giornata
+      setProgressionTick((t) => t + 1); // re-fetch progression
+    } catch (error) {
+      console.error('[TestGameHeader] Failed to advance giornata:', error);
+    } finally {
+      setAdvanceLoading(false);
+    }
+  }, [userKey, advanceLoading, onReset]);
 
   // Update virtual countdown every second
   useEffect(() => {
@@ -358,40 +398,31 @@ export function TestGameHeader({
           </div>
         )}
 
-        {/* Test mode info - virtual date calendar with controls */}
+        {/* Sequential giornata progression controls */}
         <div className="mt-3 pt-3 border-t border-white/20 game-header-reset-responsive">
           <div className="text-xs text-white/80 mb-2">
-            📅 Data simulata: {formatDisplay()}
+            Giornata {weekNumber ?? '--'} di {maxWeek}
           </div>
 
-          {/* Virtual clock controls */}
           <div className="flex justify-center gap-2">
             <button
-              onClick={() => {
-                // Fast forward to next week (7 days)
-                const oneWeekMs = 7 * 24 * 60 * 60 * 1000;
-                const storageKey = 'swipick:virtual-clock:reference';
-                try {
-                  const stored = localStorage.getItem(storageKey);
-                  if (stored) {
-                    const state = JSON.parse(stored);
-                    state.fastForwardOffset = (state.fastForwardOffset || 0) + oneWeekMs;
-                    localStorage.setItem(storageKey, JSON.stringify(state));
-                    window.location.reload(); // Refresh to apply new virtual time
-                  }
-                } catch (error) {
-                  console.warn('Failed to update virtual clock:', error);
-                }
-              }}
-              className="inline-flex items-center px-2 py-1 text-xs bg-blue-500/80 hover:bg-blue-600/80 rounded-full transition-colors"
-              title="Avanza di una settimana"
+              onClick={handleNextGiornata}
+              disabled={advanceLoading || (weekNumber != null && weekNumber >= maxWeek)}
+              className="inline-flex items-center px-3 py-1 text-xs bg-blue-500/80 hover:bg-blue-600/80 disabled:bg-blue-500/40 rounded-full transition-colors"
+              title="Vai alla prossima giornata"
             >
-              <svg className="-ml-0.5 mr-1 h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 9l3 3-3 3m-6 0l3-3-3-3" />
-              </svg>
-              +1 Settimana
+              {advanceLoading ? (
+                <svg className="animate-spin -ml-0.5 mr-1 h-3 w-3 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="m4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                </svg>
+              ) : (
+                <svg className="-ml-0.5 mr-1 h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 9l3 3-3 3m-6 0l3-3-3-3" />
+                </svg>
+              )}
+              Prossima giornata
             </button>
-
           </div>
         </div>
       </div>

--- a/apps/frontend/frontend-service/app/risultati/test-risultati/page.tsx
+++ b/apps/frontend/frontend-service/app/risultati/test-risultati/page.tsx
@@ -12,7 +12,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Toast } from '@/src/components/Toast';
 import confetti from 'canvas-confetti';
 import { useVirtualClock } from '../../gioca/components/VirtualClock/VirtualClock';
-import { calculateActiveWeek, WeekInfo } from '../../gioca/utils/weekCalculator';
+import { WeekInfo } from '../../gioca/utils/weekCalculator';
 
 interface Fixture {
   id: number;
@@ -318,21 +318,31 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
   const [storedFinalScore, setStoredFinalScore] = useState<{ revealed: number; correct: number; percent: number } | null>(null);
   const [finalScoreLoading, setFinalScoreLoading] = useState(false);
 
-  // Calculate active week and fetch fixtures based on virtual time
+  // Determine the reached giornata from the server-side per-user progression.
+  // currentWeek = highest giornata available in Risultati; results for weeks
+  // 1..currentWeek are always inspectable (the test dataset is fully FINISHED).
   useEffect(() => {
-    const updateActiveWeek = async () => {
+    if (!userKey) return;
+    const loadProgression = async () => {
       try {
-        // Calculate which week should be active for predictions
-        const weekInfo = await calculateActiveWeek(virtualTime);
-        setActiveWeekInfo(weekInfo);
-        console.log(`[TestRisultati] Active week updated: ${weekInfo.activeWeek}, status: ${weekInfo.status}`);
+        const resp = await apiClient.getTestProgression(userKey);
+        const data = (resp as { data?: { currentWeek?: number } })?.data ?? resp;
+        const currentWeek = Number((data as { currentWeek?: number })?.currentWeek ?? 1);
+        setActiveWeekInfo({ activeWeek: currentWeek, status: 'completed' });
+
+        // Default the view to the current giornata when no explicit week in URL
+        const urlWeek = searchParams?.get('week');
+        if (!urlWeek) {
+          setSelectedWeek(currentWeek);
+        }
+        console.log(`[TestRisultati] Reached giornata (progression): ${currentWeek}`);
       } catch (error: unknown) {
-        console.warn('Could not calculate active week:', error);
+        console.warn('Could not load test progression:', error);
       }
     };
 
-    updateActiveWeek();
-  }, [virtualTime]); // Recalculate when virtual time changes
+    loadProgression();
+  }, [userKey, searchParams]);
 
   // Use dynamic virtual current week based on virtual time
   const VIRTUAL_CURRENT_WEEK = activeWeekInfo.activeWeek;
@@ -440,47 +450,11 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
     } catch {}
   }, [revealed, revealKey]);
 
-  // Reveal function with virtual timing logic
+  // Reveal function
   const onReveal = useCallback(async (fixtureId: string, anchorEl?: HTMLElement) => {
-    // For current and future virtual weeks, check if the virtual match has "finished"
-    if (selectedWeek >= activeWeekInfo.activeWeek) {
-      // Use virtual clock to determine if match has been played
-      const fixture = fixtures.find(f => String(f.id) === fixtureId);
-      if (fixture) {
-        // Get match date from fixture
-        const matchDate = new Date(fixture.date || fixture.kickoff || fixture.datetime || fixture.match_date || '');
-
-        // Add 2 hours (120 minutes) to match start time to simulate match completion
-        const matchEndTime = new Date(matchDate.getTime() + (120 * 60 * 1000));
-
-        // Check if virtual time has passed the match end time
-        const virtuallyFinished = virtualTime.getTime() >= matchEndTime.getTime();
-
-        if (!virtuallyFinished) {
-          setToast('La partita non è ancora terminata');
-          setTimeout(() => setToast(null), 3000); // Auto-dismiss after 3 seconds
-          console.log(`[TestRisultati] 🚫 Reveal blocked - virtual match not finished yet:`, {
-            fixtureId,
-            week: selectedWeek,
-            matchDate: matchDate.toISOString(),
-            matchEndTime: matchEndTime.toISOString(),
-            virtualTime: virtualTime.toISOString(),
-            reason: 'virtual match still in progress or not started'
-          });
-          return;
-        }
-
-        console.log(`[TestRisultati] ✅ Reveal allowed - virtual match finished:`, {
-          fixtureId,
-          week: selectedWeek,
-          matchEndTime: matchEndTime.toISOString(),
-          virtualTime: virtualTime.toISOString()
-        });
-      }
-    } else {
-      // For past weeks, always allow reveals (no time restrictions)
-      console.log(`[TestRisultati] ✅ Reveal allowed - past week ${selectedWeek} (virtual current week ${activeWeekInfo.activeWeek})`);
-    }
+    // The test dataset is fully FINISHED, so results are always available for
+    // any reached giornata — reveal is never gated by a virtual clock. The user
+    // can verify the giornata they just predicted immediately.
 
     // Allow reveal
     setRevealed(prev => ({ ...prev, [fixtureId]: true }));
@@ -503,7 +477,7 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
     setRecentlyRevealed({ id: fixtureId, origin });
 
     console.log(`[TestRisultati] 🔍 Revealed fixture ${fixtureId} in week ${selectedWeek}`);
-  }, [selectedWeek, fixtures, userKey, activeWeekInfo, virtualTime]);
+  }, [selectedWeek]);
 
   // Helper function to get prediction data for a fixture
   const getPredictionData = useCallback((fixtureId: number) => {
@@ -687,7 +661,7 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
       centerWeek + 5,  // 5 weeks forward
       centerWeek + 6,  // 6 weeks forward
       centerWeek + 7   // 7 weeks forward
-    ].filter(w => w >= 1 && w <= 38); // Valid week range
+    ].filter(w => w >= 1 && w <= activeWeekInfo.activeWeek); // Only reached giornate
 
     console.log(`[TestRisultati] 🔄 Preloading 10 weeks around ${centerWeek}:`, weeksToPreload);
 
@@ -695,7 +669,7 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
     await Promise.all(weeksToPreload.map(week => fetchWeekData(week)));
 
     console.log(`[TestRisultati] ✅ 10-week preloading completed for weeks:`, weeksToPreload);
-  }, [fetchWeekData]);
+  }, [fetchWeekData, activeWeekInfo.activeWeek]);
 
   // Initial data loading and preloading
   useEffect(() => {
@@ -746,7 +720,8 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
   // Optimized week navigation - no immediate re-fetching since data is cached
   const updateWeek = useCallback((w: number) => {
     console.log('[TestRisultati] 🔄 updateWeek called', { from: selectedWeek, to: w, timestamp: new Date().toISOString() });
-    const next = Math.max(1, Math.min(38, w));
+    // Cap navigation to the reached giornata (no peeking at future weeks)
+    const next = Math.max(1, Math.min(activeWeekInfo.activeWeek, w));
 
     // Check if target week is already cached
     const isCached = isWeekCached(next);
@@ -757,7 +732,7 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
     setPendingWeekForUrl(next);
 
     console.log('[TestRisultati] ✅ State updates queued - no API calls needed due to caching');
-  }, [selectedWeek, isWeekCached]);
+  }, [selectedWeek, isWeekCached, activeWeekInfo.activeWeek]);
 
   // Reset function
   const handleReset = async () => {
@@ -1110,24 +1085,28 @@ const TestRisultatiPageContent = React.memo(function TestRisultatiPageContent() 
               )}
             </div>
 
-            {/* Next week (right) */}
+            {/* Next week (right) — only up to the reached giornata */}
             <div className="absolute right-4 top-1/2 -translate-y-1/2 text-white text-sm opacity-60 text-right">
-              <button
-                onClick={(e) => {
-                  console.log('[TestRisultati] ➡️ NEXT WEEK BUTTON CLICKED', {
-                    currentWeek: selectedWeek,
-                    targetWeek: selectedWeek + 1,
-                    timestamp: new Date().toISOString(),
-                    event: e.type,
-                    target: e.target
-                  });
-                  updateWeek(selectedWeek + 1);
-                  console.log('[TestRisultati] ➡️ updateWeek call completed for next week');
-                }}
-                className="font-medium hover:opacity-80 transition-opacity cursor-pointer"
-              >
-                <div>Giornata {selectedWeek + 1}</div>
-              </button>
+              {selectedWeek < activeWeekInfo.activeWeek ? (
+                <button
+                  onClick={(e) => {
+                    console.log('[TestRisultati] ➡️ NEXT WEEK BUTTON CLICKED', {
+                      currentWeek: selectedWeek,
+                      targetWeek: selectedWeek + 1,
+                      timestamp: new Date().toISOString(),
+                      event: e.type,
+                      target: e.target
+                    });
+                    updateWeek(selectedWeek + 1);
+                    console.log('[TestRisultati] ➡️ updateWeek call completed for next week');
+                  }}
+                  className="font-medium hover:opacity-80 transition-opacity cursor-pointer"
+                >
+                  <div>Giornata {selectedWeek + 1}</div>
+                </button>
+              ) : (
+                <div className="h-6 select-none" />
+              )}
             </div>
           </div>
 

--- a/apps/frontend/frontend-service/lib/api-client.ts
+++ b/apps/frontend/frontend-service/lib/api-client.ts
@@ -400,6 +400,17 @@ class ApiClient {
     });
   }
 
+  // Test Mode sequential giornata progression
+  async getTestProgression(userId: string) {
+    return this.request(`/test-mode/progression/${userId}`);
+  }
+
+  async advanceTestProgression(userId: string) {
+    return this.request(`/test-mode/progression/${userId}/next`, {
+      method: 'POST',
+    });
+  }
+
   async seedTestFixtures() {
     return this.request('/test-mode/seed', {
       method: 'POST',


### PR DESCRIPTION
Sostituisce l'orologio virtuale in tempo reale (che rendeva la giornata "random") con una **progressione sequenziale per-utente lato server**, così Gioca e Risultati restano allineati sulla stessa stagione test (2023-24) e avanzano giornata per giornata.

**Backend (gaming-services)**
- Tabella isolata `test_user_progress` (entity + migration). `currentWeek` parte da 1.
- `getProgression` / `advanceProgression` (cap all'ultima giornata); `GET /test-mode/progression/:userId`, `POST .../next`.
- `resetUserTestData` azzera a 1; rimosso `autoCompleteVirtualFixtures`.

**BFF** — proxy delle due rotte.

**Frontend web**
- `TestGameHeader`: giornata dalla progressione; bottone **"Prossima giornata"** (avanza in sequenza).
- `test-risultati`: apre sulla giornata corrente, navigazione `1..currentWeek`, reveal sempre consentito (dati test già FINISHED → verifica immediata).

**Verifica:** gaming-services tsc+lint+33 test ✓ · BFF tsc ✓ · frontend tsc + next build ✓.

⚠️ Richiede la migration `CreateTestUserProgress1761000000000` su prod (CREATE TABLE isolata, eseguita manualmente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)