### PR TITLE
fix(test-mode): team logos for full league (Salernitana, Frosinone, AS Roma)

### DIFF
--- a/apps/frontend/frontend-service/app/gioca/components/GameSummaryScreen/GameSummaryScreen.tsx
+++ b/apps/frontend/frontend-service/app/gioca/components/GameSummaryScreen/GameSummaryScreen.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useState } from 'react';
+import { resolveTeamLogo } from '../../../../lib/club-logos';
 import type { Fixture, PredictionRecord } from '../../types';
 
 interface GameSummaryScreenProps {
@@ -12,35 +13,6 @@ interface GameSummaryScreenProps {
   headerHeight?: number;
 }
 
-// Helper function to get team logo path
-const getTeamLogoPath = (teamName: string): string => {
-  // Map team names to logo files
-  const logoMap: Record<string, string> = {
-    'Juventus': 'JuventusFcLogo.png',
-    'AC Milan': 'AcMilanLogo.png',
-    'Inter': 'FcInternazionaleMilano.png',
-    'Roma': 'AsRomaLogo.png',
-    'Napoli': 'NapolLogo.png',
-    'Lazio': 'StemmaLazioCentenarioLogo.png',
-    'Atalanta': 'AtalantaBcLogo.png',
-    'Fiorentina': 'AcfFiorentinaLogo.png',
-    'Bologna': 'LogobolognaLogo.png',
-    'Torino': 'TorinoFcLogo.png',
-    'Udinese': 'UdineseLogo.png',
-    'Sassuolo': 'SassuoloLogo.png',
-    'Verona': 'HellasVeronaFcLogo.png',
-    'Genoa': 'GenoaCfcLogo.png',
-    'Cagliari': 'CagliariCalcioLogo.png',
-    'Lecce': 'LecceLogo.png',
-    'Monza': 'AcMonzaLogo.png',
-    'Empoli': 'EmpolFcLogo.png',
-    'Como': 'ComoCalcioLogo.png',
-    'Parma': 'ParmaLogo.png'
-  };
-
-  return logoMap[teamName] ? `/teams/${logoMap[teamName]}` : '';
-};
-
 // Team logo component with fallback
 const TeamLogo: React.FC<{
   src?: string;
@@ -48,7 +20,9 @@ const TeamLogo: React.FC<{
   teamName: string;
 }> = ({ src, alt, teamName }) => {
   const [imageError, setImageError] = useState(false);
-  const logoPath = src || getTeamLogoPath(teamName);
+  // Centralized resolver: normalizes names (e.g. "AS Roma", "Salernitana",
+  // "Frosinone") and falls back to the backend logo path.
+  const logoPath = resolveTeamLogo(teamName, src);
 
   if (!logoPath || imageError) {
     return (

--- a/apps/frontend/frontend-service/app/gioca/components/TestGameSummaryScreen/TestGameSummaryScreen.tsx
+++ b/apps/frontend/frontend-service/app/gioca/components/TestGameSummaryScreen/TestGameSummaryScreen.tsx
@@ -5,6 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { apiClient } from '../../../../lib/api-client';
+import { resolveTeamLogo } from '../../../../lib/club-logos';
 import type { Fixture, PredictionRecord } from '../../types';
 
 interface TestGameSummaryScreenProps {
@@ -36,34 +37,6 @@ interface WeeklyStatsResponse {
 }
 
 // Helper function to get team logo path
-const getTeamLogoPath = (teamName: string): string => {
-  // Map team names to logo files
-  const logoMap: Record<string, string> = {
-    'Juventus': 'JuventusFcLogo.png',
-    'AC Milan': 'AcMilanLogo.png',
-    'Inter': 'FcInternazionaleMilano.png',
-    'Roma': 'AsRomaLogo.png',
-    'Napoli': 'NapolLogo.png',
-    'Lazio': 'StemmaLazioCentenarioLogo.png',
-    'Atalanta': 'AtalantaBcLogo.png',
-    'Fiorentina': 'AcfFiorentinaLogo.png',
-    'Bologna': 'LogobolognaLogo.png',
-    'Torino': 'TorinoFcLogo.png',
-    'Udinese': 'UdineseLogo.png',
-    'Sassuolo': 'SassuoloLogo.png',
-    'Verona': 'HellasVeronaFcLogo.png',
-    'Genoa': 'GenoaCfcLogo.png',
-    'Cagliari': 'CagliariCalcioLogo.png',
-    'Lecce': 'LecceLogo.png',
-    'Monza': 'AcMonzaLogo.png',
-    'Empoli': 'EmpolFcLogo.png',
-    'Como': 'ComoCalcioLogo.png',
-    'Parma': 'ParmaLogo.png'
-  };
-
-  return logoMap[teamName] ? `/teams/${logoMap[teamName]}` : '';
-};
-
 // Team logo component with fallback
 const TeamLogo: React.FC<{
   src?: string;
@@ -71,7 +44,9 @@ const TeamLogo: React.FC<{
   teamName: string;
 }> = ({ src, alt, teamName }) => {
   const [imageError, setImageError] = useState(false);
-  const logoPath = src || getTeamLogoPath(teamName);
+  // Centralized resolver: normalizes names (e.g. "AS Roma", "Salernitana",
+  // "Frosinone") and falls back to the backend logo path.
+  const logoPath = resolveTeamLogo(teamName, src);
 
   if (!logoPath || imageError) {
     return (

--- a/apps/frontend/frontend-service/app/risultati/test-risultati/page.tsx
+++ b/apps/frontend/frontend-service/app/risultati/test-risultati/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useMemo, useCallback, Suspense } from 'reac
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuthContext } from '@/src/contexts/AuthContext';
 import { apiClient } from '@/lib/api-client';
+import { resolveTeamLogo } from '@/lib/club-logos';
 import { RiFootballLine } from 'react-icons/ri';
 import { IoShareOutline } from 'react-icons/io5';
 import { FaMedal } from 'react-icons/fa';
@@ -58,34 +59,6 @@ interface WeeklyStatsResponse {
   }>;
 }
 
-// Helper function to get team logo path
-const getTeamLogoPath = (teamName: string): string => {
-  const logoMap: Record<string, string> = {
-    'Juventus': 'JuventusFcLogo.png',
-    'AC Milan': 'AcMilanLogo.png',
-    'Inter': 'FcInternazionaleMilano.png',
-    'Roma': 'AsRomaLogo.png',
-    'Napoli': 'NapolLogo.png',
-    'Lazio': 'StemmaLazioCentenarioLogo.png',
-    'Atalanta': 'AtalantaBcLogo.png',
-    'Fiorentina': 'AcfFiorentinaLogo.png',
-    'Bologna': 'LogobolognaLogo.png',
-    'Torino': 'TorinoFcLogo.png',
-    'Udinese': 'UdineseLogo.png',
-    'Sassuolo': 'SassuoloLogo.png',
-    'Verona': 'HellasVeronaFcLogo.png',
-    'Genoa': 'GenoaCfcLogo.png',
-    'Cagliari': 'CagliariCalcioLogo.png',
-    'Lecce': 'LecceLogo.png',
-    'Monza': 'AcMonzaLogo.png',
-    'Empoli': 'EmpolFcLogo.png',
-    'Como': 'ComoCalcioLogo.png',
-    'Parma': 'ParmaLogo.png'
-  };
-
-  return logoMap[teamName] ? `/teams/${logoMap[teamName]}` : '';
-};
-
 // Team logo component with fallback
 const TeamLogo: React.FC<{
   src?: string;
@@ -93,7 +66,9 @@ const TeamLogo: React.FC<{
   teamName: string;
 }> = ({ src, alt, teamName }) => {
   const [imageError, setImageError] = useState(false);
-  const logoPath = src || getTeamLogoPath(teamName);
+  // Use the centralized resolver: it normalizes team names (handles "AS Roma",
+  // "Salernitana", "Frosinone", etc.) and falls back to the backend logo path.
+  const logoPath = resolveTeamLogo(teamName, src);
 
   if (!logoPath || imageError) {
     return (


### PR DESCRIPTION
## Problema
In modalità test alcuni loghi squadra erano assenti (es. **Salernitana**, **Frosinone**, **AS Roma**).

## Causa
La modalità test usa il dataset Serie A **2023-24** (che include Salernitana e Frosinone) e il backend restituisce **"AS Roma"** (non "Roma"). Tre schermate usavano una `logoMap` locale hardcoded e incompleta: mancavano quelle squadre (oltre a Spal/Cremonese/Pisa) e la chiave era `Roma`, quindi nessun match → logo vuoto.

Il lato Gioca (MatchCard) funzionava già perché usa il resolver condiviso `resolveTeamLogo`, che normalizza i nomi.

## Fix
Sostituita la mappa hardcoded con `resolveTeamLogo(teamName, src)` (normalizzazione nomi + fallback al path del backend) in:
- `app/risultati/test-risultati/page.tsx`
- `app/gioca/components/TestGameSummaryScreen/TestGameSummaryScreen.tsx`
- `app/gioca/components/GameSummaryScreen/GameSummaryScreen.tsx`

## Verifica
- `tsc --noEmit` passa pulito ✅
- Net: -88 / +12 righe (rimossa duplicazione)

🤖 Generated with [Claude Code](https://claude.com/claude-code)