### PR TITLE
fix(risultati): apri sull'ultima giornata GIOCATA (stagione conclusa), non quella in arrivo

### DIFF
--- a/apps/backend/bff/src/app.controller.ts
+++ b/apps/backend/bff/src/app.controller.ts
@@ -104,23 +104,40 @@ export class AppController {
     return this.appService.forwardToGamingServices(endpoint);
   }
 
+  // Most recent (season, week) with at least one played match.
+  @Get('api/fixtures/last-played')
+  async getLastPlayed() {
+    this.logger.log('Forwarding last-played request to Gaming Services');
+    return this.appService.forwardToGamingServices(
+      `/api/fixtures/last-played`,
+    );
+  }
+
   @Get('api/fixtures/week/:weekNumber')
-  async getFixturesByWeek(@Param('weekNumber') weekNumber: string) {
+  async getFixturesByWeek(
+    @Param('weekNumber') weekNumber: string,
+    @Req() req: Request,
+  ) {
     this.logger.log(
       `Forwarding fixtures week ${weekNumber} request to Gaming Services`,
     );
+    const queryString = req.url.split('?')[1] || '';
     return this.appService.forwardToGamingServices(
-      `/api/fixtures/week/${weekNumber}`,
+      `/api/fixtures/week/${weekNumber}${queryString ? `?${queryString}` : ''}`,
     );
   }
 
   @Get('api/fixtures/week/:weekNumber/daterange')
-  async getWeekDateRange(@Param('weekNumber') weekNumber: string) {
+  async getWeekDateRange(
+    @Param('weekNumber') weekNumber: string,
+    @Req() req: Request,
+  ) {
     this.logger.log(
       `Forwarding week ${weekNumber} date range request to Gaming Services`,
     );
+    const queryString = req.url.split('?')[1] || '';
     return this.appService.forwardToGamingServices(
-      `/api/fixtures/week/${weekNumber}/daterange`,
+      `/api/fixtures/week/${weekNumber}/daterange${queryString ? `?${queryString}` : ''}`,
     );
   }
 
@@ -283,10 +300,11 @@ export class AppController {
   @Get('api/match-cards/week/:weekNumber')
   async getMatchCardsByWeek(
     @Param('weekNumber') weekNumber: string,
-    @Query('userId') userId?: string,
+    @Req() req: Request,
   ) {
     this.logger.log(`Getting match cards for week ${weekNumber}`);
-    const endpoint = `/api/match-cards/week/${weekNumber}${userId ? `?userId=${userId}` : ''}`;
+    const queryString = req.url.split('?')[1] || '';
+    const endpoint = `/api/match-cards/week/${weekNumber}${queryString ? `?${queryString}` : ''}`;
     return this.appService.forwardToGamingServices(endpoint);
   }
 

--- a/apps/frontend/frontend-service/app/risultati/page.tsx
+++ b/apps/frontend/frontend-service/app/risultati/page.tsx
@@ -140,6 +140,10 @@ function RisultatiPageContent() {
 
   // Per-game reveal state (Test Mode) - initialize with live week to avoid loading wrong week initially
   const [selectedWeek, setSelectedWeek] = useState<number>(liveWeekData?.currentWeek || 7);
+  // Season to read results from. Resolved from /fixtures/last-played: during the
+  // pre-season gap this is the just-concluded season (e.g. 2025), so Risultati
+  // shows its final giornata instead of the upcoming (Gioca) season.
+  const [selectedSeason, setSelectedSeason] = useState<number | undefined>(undefined);
   const [userId, setUserId] = useState<string | null>(null);
   const [weekCards, setWeekCards] = useState<MatchCard[]>([]);
   const [revealed, setRevealed] = useState<Record<string, boolean>>({});
@@ -308,15 +312,35 @@ function RisultatiPageContent() {
     }
   }, [searchParams]);
 
-  // Set selectedWeek from live week data (unless explicitly set via URL)
+  // Default Risultati to the last *played* (season, week) — unless a week is set
+  // via URL. During the pre-season gap this is the previous season's final
+  // giornata (e.g. {2025, 38}); once the current season has a played match it
+  // becomes {currentSeason, latestWeek}. This is intentionally NOT driven by the
+  // live (Gioca) week, which points at the upcoming, not-yet-played giornata.
   useEffect(() => {
-    if (liveWeekData && !searchParams?.get('week')) {
-      setSelectedWeek(liveWeekData.currentWeek);
-      if (DEBUG_RISULTATI) {
-        try { console.log('[risultati] setting live week from useLiveWeek', { week: liveWeekData.currentWeek }); } catch {}
+    if (searchParams?.get('week')) return; // explicit URL week wins
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await apiClient.getLastPlayed();
+        const lp = (resp && typeof resp === 'object' && 'data' in (resp as Record<string, unknown>))
+          ? (resp as { data?: { season?: number; week?: number } }).data
+          : (resp as unknown as { season?: number; week?: number });
+        if (!cancelled && lp && Number.isFinite(Number(lp.week))) {
+          setSelectedSeason(typeof lp.season === 'number' ? lp.season : undefined);
+          setSelectedWeek(Number(lp.week));
+          if (DEBUG_RISULTATI) {
+            try { console.log('[risultati] last-played', lp); } catch {}
+          }
+        }
+      } catch (e) {
+        if (DEBUG_RISULTATI) {
+          try { console.warn('[risultati] last-played failed', e); } catch {}
+        }
       }
-    }
-  }, [liveWeekData, searchParams]);
+    })();
+    return () => { cancelled = true; };
+  }, [searchParams]);
 
   // Set active tab to week for live mode
   useEffect(() => {
@@ -426,7 +450,7 @@ function RisultatiPageContent() {
     const run = async () => {
       try {
         // For live mode, use fixtures table as single source of truth
-        const fixturesResp = await apiClient.getFixturesByWeek(selectedWeek) as unknown as { data?: FixtureRow[] } | FixtureRow[];
+        const fixturesResp = await apiClient.getFixturesByWeek(selectedWeek, selectedSeason) as unknown as { data?: FixtureRow[] } | FixtureRow[];
         const fixtures = Array.isArray(fixturesResp) ? fixturesResp : fixturesResp?.data ?? [];
 
         // Convert fixtures to MatchCard format for consistency
@@ -468,14 +492,14 @@ function RisultatiPageContent() {
       }
     };
     run();
-  }, [selectedWeek, userId]);
+  }, [selectedWeek, selectedSeason, userId]);
 
   // Preload next week's range for the header (placeholder only)
   useEffect(() => {
     const run = async () => {
       const nxt = selectedWeek + 1;
       try {
-        const resp = await apiClient.getLiveMatchCardsByWeek(nxt, userId ?? undefined) as unknown as { data?: MatchCard[] } | MatchCard[];
+        const resp = await apiClient.getLiveMatchCardsByWeek(nxt, userId ?? undefined, selectedSeason) as unknown as { data?: MatchCard[] } | MatchCard[];
         const arr = Array.isArray(resp) ? resp : resp?.data ?? [];
         if (Array.isArray(arr) && arr.length) {
           const times = (arr as MatchCard[]).map((m) => new Date(m.kickoff.iso).getTime());
@@ -489,14 +513,14 @@ function RisultatiPageContent() {
       } catch { setNextWeekRange(null); }
     };
     run();
-  }, [selectedWeek, userId]);
+  }, [selectedWeek, selectedSeason, userId]);
 
   // Fetch raw fixtures with scores for the selected week (fallback for result display)
   useEffect(() => {
     const run = async () => {
       try {
         // For live mode, get fixtures by specific week from fixtures table
-        const resp = await apiClient.getFixturesByWeek(selectedWeek) as unknown as { data?: Array<FixtureRow> } | Array<FixtureRow>;
+        const resp = await apiClient.getFixturesByWeek(selectedWeek, selectedSeason) as unknown as { data?: Array<FixtureRow> } | Array<FixtureRow>;
         const arr: FixtureRow[] = Array.isArray(resp) ? resp : (resp?.data ?? []);
         if (DEBUG_RISULTATI) {
           try {
@@ -562,7 +586,7 @@ function RisultatiPageContent() {
 
     setFixtureScoresLoaded(false); // Reset loading state when week changes
     run();
-  }, [selectedWeek]);
+  }, [selectedWeek, selectedSeason]);
 
   // Helper: load weekly stats when needed
   const loadWeeklyStats = useCallback(async (week: number) => {
@@ -660,7 +684,7 @@ function RisultatiPageContent() {
       try {
         const bffUrl = process.env.NEXT_PUBLIC_BFF_API_URL || 'http://localhost:9000/api';
         const response = await fetch(
-          `${bffUrl}/final-week-scores/${userId}/week/${selectedWeek}/percentile?mode=live`,
+          `${bffUrl}/final-week-scores/${userId}/week/${selectedWeek}/percentile?mode=live${selectedSeason ? `&season=${selectedSeason}` : ''}`,
         );
 
         if (response.ok) {
@@ -677,7 +701,7 @@ function RisultatiPageContent() {
     };
 
     fetchPercentile();
-  }, [userId, selectedWeek]);
+  }, [userId, selectedWeek, selectedSeason]);
 
   // Share handler (defined after meter so it can reference it safely)
   const handleShare = useCallback(async () => {

--- a/apps/frontend/frontend-service/lib/api-client.ts
+++ b/apps/frontend/frontend-service/lib/api-client.ts
@@ -121,20 +121,33 @@ class ApiClient {
     return this.request(`/fixtures/next${qs ? `?${qs}` : ''}`);
   }
 
-  // Get fixtures by week number from database
-  async getFixturesByWeek(weekNumber: number) {
-    return this.request(`/fixtures/week/${weekNumber}`);
+  // Most recent (season, week) with at least one played match. Drives the
+  // Risultati screen's initial open: during the pre-season gap it returns the
+  // previous season's last giornata (e.g. {season:2025, week:38}).
+  async getLastPlayed() {
+    return this.request(`/fixtures/last-played`);
+  }
+
+  // Get fixtures by week number from database. Pass season to read a specific
+  // season (e.g. the just-concluded one); omit to use the backend's current season.
+  async getFixturesByWeek(weekNumber: number, season?: number) {
+    const qs = season ? `?season=${season}` : '';
+    return this.request(`/fixtures/week/${weekNumber}${qs}`);
   }
 
   // Get date range for a specific week from database
-  async getWeekDateRange(weekNumber: number) {
-    return this.request(`/fixtures/week/${weekNumber}/daterange`);
+  async getWeekDateRange(weekNumber: number, season?: number) {
+    const qs = season ? `?season=${season}` : '';
+    return this.request(`/fixtures/week/${weekNumber}/daterange${qs}`);
   }
 
   // Get enriched match cards by week number (live mode equivalent of test mode match cards)
-  async getLiveMatchCardsByWeek(weekNumber: number, userId?: string) {
-    const params = userId ? `?userId=${userId}` : '';
-    return this.request(`/match-cards/week/${weekNumber}${params}`);
+  async getLiveMatchCardsByWeek(weekNumber: number, userId?: string, season?: number) {
+    const params = new URLSearchParams();
+    if (userId) params.set('userId', userId);
+    if (season) params.set('season', String(season));
+    const qs = params.toString();
+    return this.request(`/match-cards/week/${weekNumber}${qs ? `?${qs}` : ''}`);
   }
 
   // Teams API


### PR DESCRIPTION
## Problema
In modalità **Live**, all'inizio della nuova stagione (2026-27, `CURRENT_SEASON=2026`, nessuna giornata ancora giocata):
- **Gioca** mostra correttamente la prossima giornata della nuova stagione.
- **Risultati** mostrava una giornata della **nuova** stagione, invece dell'**ultima giornata dell'ultima stagione conclusa** (2025/38) come stabilito.

## Causa
`app/risultati/page.tsx` pilotava la giornata dalla stessa fonte di Gioca (`useLiveWeek` → giornata *futura*) e chiamava `getFixturesByWeek(week)` **senza stagione** → il backend ripiegava su `CURRENT_SEASON=2026`.

Lato gaming-services la logica giusta esisteva già (`GET /fixtures/last-played` → `getLastPlayedWeek()`, e `?season=` su `/fixtures/week/:n`), ma il cablaggio a monte era incompleto: il BFF non esponeva `last-played` e **scartava la query string** sui proxy week/match-cards.

## Fix (solo BFF + frontend; gaming-services già pronto)
- **BFF** (`app.controller.ts`): proxy `GET /fixtures/last-played`; inoltro della query string su `/fixtures/week/:n`, `/fixtures/week/:n/daterange`, `/match-cards/week/:n` (così `?season=` arriva a gaming-services).
- **api-client**: `getLastPlayed()`; parametro opzionale `season` su `getFixturesByWeek`, `getWeekDateRange`, `getLiveMatchCardsByWeek`.
- **Risultati** (live): all'apertura risolve `{season, week}` da `/fixtures/last-played` e propaga `selectedSeason` a tutte le fetch della giornata.

Comportamento: durante il pre-season Risultati apre su **2025/38**; appena la 2026 gioca la 1ª giornata diventa **{2026, ultima giocata}**, senza altri interventi.

## Fuori scope (concordato)
- Navigazione tra stagioni in Risultati (per ora no).
- Statistiche utente vuote sulla 2025/38 se non c'erano pronostici: ok, si mostrano i soli risultati.

## Verifica
- `tsc --noEmit` pulito su frontend **e** BFF ✅
- Post-deploy: verificherò live `GET /api/fixtures/last-played` → atteso `{season:2025, week:38}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)