### PR TITLE
feat(auth): email brandizzate per reset password e re-invio verifica

### DIFF
--- a/apps/backend/bff/src/config/firebase.config.ts
+++ b/apps/backend/bff/src/config/firebase.config.ts
@@ -276,10 +276,26 @@ export class FirebaseConfigService {
   }
 
   /**
-   * Note: Password reset emails must be sent from client-side Firebase Auth
-   * This is a Firebase security requirement - password reset links can only be generated client-side
-   * Use sendPasswordResetEmail() from firebase/auth on the frontend
+   * Generate a password reset link via the Admin SDK so the email can be sent
+   * from our own branded EmailService (instead of Firebase's default template).
    */
+  async generatePasswordResetLink(email: string): Promise<string> {
+    try {
+      const auth = this.getAuth();
+      if (!auth) {
+        throw new Error('Firebase Admin SDK non inizializzato');
+      }
+
+      const link = await auth.generatePasswordResetLink(email);
+      this.logger.log(`Password reset link generated for: ${email}`);
+      return link;
+    } catch (error) {
+      this.logger.error('Failed to generate password reset link', error);
+      throw new Error(
+        'Errore durante la generazione del link di reset password',
+      );
+    }
+  }
 }
 
 @Global()

--- a/apps/backend/bff/src/modules/users/users.controller.ts
+++ b/apps/backend/bff/src/modules/users/users.controller.ts
@@ -277,6 +277,27 @@ export class UsersController {
   }
 
   /**
+   * Re-send the branded email verification message
+   * POST /api/users/resend-verification
+   */
+  @Post('resend-verification')
+  @HttpCode(HttpStatus.OK)
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  async resendVerification(@Body() body: { email: string }): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    this.logger.log(`Verification resend request for email: ${body.email}`);
+
+    await this.usersService.resendVerificationEmail(body.email);
+
+    return {
+      success: true,
+      message: "Email di verifica inviata se l'indirizzo esiste",
+    };
+  }
+
+  /**
    * Sync password reset with database after Firebase reset
    * POST /api/users/sync-password-reset
    */

--- a/apps/backend/bff/src/modules/users/users.service.ts
+++ b/apps/backend/bff/src/modules/users/users.service.ts
@@ -663,9 +663,25 @@ export class UsersService {
         );
       }
 
-      // Note: Actual password reset email is sent from client-side Firebase Auth
-      // This endpoint just validates the user exists and has email auth
-      this.logger.log(`Password reset validation passed for user: ${user.id}`);
+      // Generate the reset link via Admin SDK and send our own branded email
+      // (replaces Firebase's default password-reset template).
+      try {
+        const resetLink =
+          await this.firebaseConfig.generatePasswordResetLink(email);
+        await this.emailService.sendPasswordResetEmail(
+          email,
+          user.name,
+          resetLink,
+        );
+        this.logger.log(`Password reset email sent to user: ${user.id}`);
+      } catch (emailError) {
+        // Don't leak failures to the caller: keep the neutral response so we
+        // never reveal account existence. Log for diagnostics.
+        this.logger.error(
+          `Failed to send password reset email to ${email}`,
+          emailError,
+        );
+      }
     } catch (error) {
       if (error instanceof BadRequestException) {
         throw error;
@@ -673,6 +689,51 @@ export class UsersService {
       this.logger.error('Failed to validate password reset request', error);
       throw new BadRequestException(
         'Errore durante la validazione del reset password',
+      );
+    }
+  }
+
+  /**
+   * Re-send the email verification message using our own branded EmailService
+   * (replaces Firebase's default verification template). Neutral on missing /
+   * already-verified / social accounts so it never reveals account state.
+   */
+  async resendVerificationEmail(email: string): Promise<void> {
+    const user = await this.userRepository.findOne({ where: { email } });
+
+    if (!user) {
+      this.logger.warn(
+        `Verification resend attempted for non-existent email: ${email}`,
+      );
+      return;
+    }
+
+    if (user.emailVerified) {
+      this.logger.log(`Verification resend skipped (already verified): ${email}`);
+      return;
+    }
+
+    if (
+      user.authProvider === AuthProvider.GOOGLE ||
+      user.authProvider === AuthProvider.APPLE
+    ) {
+      this.logger.log(`Verification resend skipped (social account): ${email}`);
+      return;
+    }
+
+    try {
+      const verificationLink =
+        await this.firebaseConfig.generateEmailVerificationLink(email);
+      await this.emailService.sendVerificationEmail(
+        email,
+        user.name,
+        verificationLink,
+      );
+      this.logger.log(`Verification email re-sent to user: ${user.id}`);
+    } catch (emailError) {
+      this.logger.error(
+        `Failed to resend verification email to ${email}`,
+        emailError,
       );
     }
   }

--- a/apps/frontend/frontend-service/lib/api-client.ts
+++ b/apps/frontend/frontend-service/lib/api-client.ts
@@ -180,6 +180,22 @@ class ApiClient {
     });
   }
 
+  // Request a branded password reset email (sent server-side via our EmailService)
+  async sendPasswordReset(email: string) {
+    return this.request('/users/send-password-reset', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    });
+  }
+
+  // Re-send the branded email verification message (sent server-side)
+  async resendVerificationEmail(email: string) {
+    return this.request('/users/resend-verification', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    });
+  }
+
   async syncGoogleUser(firebaseIdToken: string) {
     console.log('🔷 [API Client] syncGoogleUser called');
     console.log('🔷 [API Client] Token length:', firebaseIdToken?.length || 0);

--- a/apps/frontend/frontend-service/src/services/auth.service.ts
+++ b/apps/frontend/frontend-service/src/services/auth.service.ts
@@ -7,8 +7,6 @@ import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   signOut,
-  sendEmailVerification as firebaseSendEmailVerification,
-  sendPasswordResetEmail,
   getIdToken,
   onAuthStateChanged as firebaseOnAuthStateChanged,
   sendSignInLinkToEmail as firebaseSendSignInLinkToEmail,
@@ -18,6 +16,7 @@ import {
 } from 'firebase/auth';
 
 import { auth } from '@/lib/firebase';
+import { apiClient } from '@/lib/api-client';
 import { FirebaseUser, ActionCodeSettings } from '../types/auth.types';
 import { getFirebaseErrorMessage } from '../utils/firebase-errors';
 
@@ -166,14 +165,12 @@ export class AuthService {
    * Send email verification to current user
    */
   async sendEmailVerification(): Promise<void> {
-    try {
-      if (!auth.currentUser) {
-        throw new Error('Nessun utente attualmente autenticato');
-      }
-      await firebaseSendEmailVerification(auth.currentUser);
-    } catch (error) {
-      throw new Error(getFirebaseErrorMessage(error));
+    const email = auth.currentUser?.email;
+    if (!email) {
+      throw new Error('Nessun utente attualmente autenticato');
     }
+    // Sent server-side via our branded EmailService (not Firebase's template).
+    await apiClient.resendVerificationEmail(email);
   }
 
   /**
@@ -193,11 +190,9 @@ export class AuthService {
    * Send password reset email
    */
   async sendPasswordReset(email: string): Promise<void> {
-    try {
-      await sendPasswordResetEmail(auth, email);
-    } catch (error) {
-      throw new Error(getFirebaseErrorMessage(error));
-    }
+    // Sent server-side via our branded EmailService (not Firebase's template).
+    // The BFF generates the reset link with the Admin SDK.
+    await apiClient.sendPasswordReset(email);
   }
 
   /**


### PR DESCRIPTION
## Contesto
Reset password e re-invio verifica usavano i **template predefiniti di Firebase** (non personalizzabili). La verifica in registrazione era già brandizzata (link via Admin SDK + `EmailService`); questi due flussi no.

## Modifiche
Tutto instradato sul vostro `EmailService` brandizzato già esistente.

**BFF**
- `firebase.config.ts`: nuovo `generatePasswordResetLink()` (Admin SDK); rimosso il commento obsoleto "must be sent client-side".
- `users.service.ts`: `sendPasswordReset()` ora genera il link e invia l'email di reset brandizzata (neutro su account inesistenti/social); nuovo `resendVerificationEmail()` (neutro su inesistente/già verificato/social).
- `users.controller.ts`: nuovo `POST /users/resend-verification`.

**Frontend**
- `api-client.ts`: `sendPasswordReset()` e `resendVerificationEmail()`.
- `auth.service.ts`: `sendPasswordReset()` e `sendEmailVerification()` ora chiamano il BFF invece del client SDK Firebase. Rimossi import Firebase inutilizzati.

## Note
- Il link di reset porta alla pagina di reset standard di Firebase (l'**email** è brandizzata); pagina di reset custom è fuori scope.
- Comportamento "neutro" preservato per non rivelare l'esistenza dell'account.

## Verifica
- `tsc --noEmit` pulito su frontend e BFF ✅
- Test modulo `users` del BFF: 6/6 pass ✅
- Post-deploy: endpoint testabili (con email inesistente → 200 neutro, nessun invio reale).

⚠️ **Deliverability** (separata, da sistemare lato DNS Aruba): vedi descrizione nella conversazione — DMARC duplicato/`p=none` e DKIM assente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)