### PR TITLE
diag(bff): endpoint temporaneo per errore generateEmailVerificationLink

### DIFF
--- a/apps/backend/bff/src/modules/users/users.controller.ts
+++ b/apps/backend/bff/src/modules/users/users.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Param,
+  Query,
   HttpCode,
   HttpStatus,
   UsePipes,
@@ -274,6 +275,18 @@ export class UsersController {
       success: true,
       message: "Email di reset password inviata se l'indirizzo esiste",
     };
+  }
+
+  /**
+   * TEMP DIAGNOSTIC — surfaces why generateEmailVerificationLink fails in prod.
+   * Tries several continueUrl variants and returns the exact Firebase error.
+   * Remove once the email-verification issue is resolved.
+   * GET /api/users/diag/verification-link?email=...
+   */
+  @Get('diag/verification-link')
+  async diagVerificationLink(@Query('email') email: string) {
+    this.logger.log(`[DIAG] verification-link check for: ${email}`);
+    return this.usersService.diagnoseVerificationLink(email);
   }
 
   /**

--- a/apps/backend/bff/src/modules/users/users.service.ts
+++ b/apps/backend/bff/src/modules/users/users.service.ts
@@ -788,6 +788,43 @@ export class UsersService {
   /**
    * Test email sending functionality
    */
+  /**
+   * TEMP DIAGNOSTIC — pinpoints why generateEmailVerificationLink fails in prod.
+   * firebaseConfig.generateEmailVerificationLink swallows the real Firebase error
+   * code, so here we call the Admin SDK directly with several continueUrl variants
+   * and return the raw error per variant. Remove once the issue is fixed.
+   */
+  async diagnoseVerificationLink(
+    email: string,
+  ): Promise<{ email: string; results: unknown[] }> {
+    const auth = this.firebaseConfig.getAuth();
+    if (!auth) {
+      return { email, results: [{ ok: false, message: 'Admin SDK null' }] };
+    }
+    const candidates: (string | undefined)[] = [
+      undefined,
+      'https://mindful-sparkle-production.up.railway.app/loginVerified',
+      'https://www.swipick.com/loginVerified',
+    ];
+    const results: unknown[] = [];
+    for (const url of candidates) {
+      try {
+        const acs = url ? { url, handleCodeInApp: false } : undefined;
+        await auth.generateEmailVerificationLink(email, acs);
+        results.push({ url: url ?? '(default/none)', ok: true });
+      } catch (e: unknown) {
+        const err = e as { code?: string; message?: string };
+        results.push({
+          url: url ?? '(default/none)',
+          ok: false,
+          code: err?.code,
+          message: err?.message,
+        });
+      }
+    }
+    return { email, results };
+  }
+
   async testEmailSending(email: string, name: string): Promise<void> {
     this.logger.log(`🧪 Testing email sending to: ${email}`);
 


### PR DESCRIPTION
Endpoint diagnostico **temporaneo** per capire perché l'email di verifica in registrazione non parte (la sonda test-email arriva, la registrazione no → differenza = step Firebase, errore ingoiato).

`GET /api/users/diag/verification-link?email=...` prova più continueUrl e ritorna il codice errore Firebase esatto. **Da rimuovere** dopo la diagnosi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)