### PR TITLE
fix(auth): email di verifica/reset — fallimenti visibili + gestione throttle Firebase

### DIFF
--- a/apps/backend/bff/src/modules/users/dto/user-response.dto.ts
+++ b/apps/backend/bff/src/modules/users/dto/user-response.dto.ts
@@ -46,6 +46,14 @@ export class UserResponseDto {
   @Transform(({ obj }) => obj.updatedAt)
   updatedAt!: Date;
 
+  /**
+   * Only set on registration: whether the verification email was actually sent.
+   * false means the account exists but the email failed (e.g. Firebase throttle)
+   * and the user should be prompted to resend.
+   */
+  @Expose()
+  verificationEmailSent?: boolean;
+
   // Exclude sensitive data
   @Exclude()
   passwordHash?: string | null;

--- a/apps/backend/bff/src/modules/users/users.controller.ts
+++ b/apps/backend/bff/src/modules/users/users.controller.ts
@@ -6,7 +6,6 @@ import {
   Delete,
   Body,
   Param,
-  Query,
   HttpCode,
   HttpStatus,
   UsePipes,
@@ -275,18 +274,6 @@ export class UsersController {
       success: true,
       message: "Email di reset password inviata se l'indirizzo esiste",
     };
-  }
-
-  /**
-   * TEMP DIAGNOSTIC — surfaces why generateEmailVerificationLink fails in prod.
-   * Tries several continueUrl variants and returns the exact Firebase error.
-   * Remove once the email-verification issue is resolved.
-   * GET /api/users/diag/verification-link?email=...
-   */
-  @Get('diag/verification-link')
-  async diagVerificationLink(@Query('email') email: string) {
-    this.logger.log(`[DIAG] verification-link check for: ${email}`);
-    return this.usersService.diagnoseVerificationLink(email);
   }
 
   /**

--- a/apps/backend/bff/src/modules/users/users.service.ts
+++ b/apps/backend/bff/src/modules/users/users.service.ts
@@ -4,6 +4,8 @@ import {
   ConflictException,
   BadRequestException,
   NotFoundException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
@@ -105,8 +107,9 @@ export class UsersService {
       const savedUser = await queryRunner.manager.save(User, user);
       await queryRunner.commitTransaction();
 
-      // Send custom verification email via Resend
+      // Send our branded verification email (link generated via Firebase Admin SDK)
       this.logger.log('🚀 Starting email verification process...');
+      let verificationEmailSent = false;
       try {
         this.logger.log('📧 Generating Firebase verification link...');
         const verificationLink =
@@ -114,9 +117,6 @@ export class UsersService {
             createUserDto.email,
           );
 
-        this.logger.log(
-          `🔗 Firebase verification link generated: ${verificationLink}`,
-        );
         this.logger.log('📤 Calling EmailService.sendVerificationEmail...');
 
         await this.emailService.sendVerificationEmail(
@@ -125,23 +125,30 @@ export class UsersService {
           verificationLink,
         );
 
+        verificationEmailSent = true;
         this.logger.log(
           `✅ Verification email sent successfully to ${createUserDto.email}`,
         );
       } catch (emailError) {
-        this.logger.error(
-          `❌ Failed to send verification email to ${createUserDto.email}`,
-          emailError,
-        );
-        this.logger.error(
-          '📊 Email error details:',
-          JSON.stringify(emailError, null, 2),
-        );
-        // Don't fail the registration if email fails - user is created successfully
+        // Never fail the registration for an email problem — the account exists
+        // and the user can resend. But surface the outcome (verificationEmailSent)
+        // so the frontend can prompt a resend instead of a false "success".
+        if (this.isThrottleError(emailError)) {
+          this.logger.warn(
+            `⏳ Verification email throttled by Firebase for ${createUserDto.email} (TOO_MANY_ATTEMPTS). User can resend later.`,
+          );
+        } else {
+          this.logger.error(
+            `❌ Failed to send verification email to ${createUserDto.email}`,
+            emailError,
+          );
+        }
       }
 
       this.logger.log(`Traditional user created successfully: ${savedUser.id}`);
-      return this.transformToResponse(savedUser);
+      const response = this.transformToResponse(savedUser);
+      response.verificationEmailSent = verificationEmailSent;
+      return response;
     } catch (error) {
       await queryRunner.rollbackTransaction();
 
@@ -675,15 +682,24 @@ export class UsersService {
         );
         this.logger.log(`Password reset email sent to user: ${user.id}`);
       } catch (emailError) {
-        // Don't leak failures to the caller: keep the neutral response so we
-        // never reveal account existence. Log for diagnostics.
+        if (this.isThrottleError(emailError)) {
+          // Throttle is global/per-IP, not account-specific, so surfacing it
+          // doesn't meaningfully reveal account existence — and the user needs
+          // to know to retry later.
+          this.logger.warn(`Password reset throttled for ${email}`);
+          throw new HttpException(
+            'Troppi tentativi ravvicinati. Riprova tra qualche minuto.',
+            HttpStatus.TOO_MANY_REQUESTS,
+          );
+        }
+        // Other failures: keep the neutral response (never reveal existence).
         this.logger.error(
           `Failed to send password reset email to ${email}`,
           emailError,
         );
       }
     } catch (error) {
-      if (error instanceof BadRequestException) {
+      if (error instanceof HttpException) {
         throw error;
       }
       this.logger.error('Failed to validate password reset request', error);
@@ -721,6 +737,8 @@ export class UsersService {
       return;
     }
 
+    // The resend flow is triggered by an authenticated user, so surfacing
+    // failures here doesn't leak account existence — unlike registration/reset.
     try {
       const verificationLink =
         await this.firebaseConfig.generateEmailVerificationLink(email);
@@ -731,9 +749,19 @@ export class UsersService {
       );
       this.logger.log(`Verification email re-sent to user: ${user.id}`);
     } catch (emailError) {
+      if (this.isThrottleError(emailError)) {
+        this.logger.warn(`Verification resend throttled for ${email}`);
+        throw new HttpException(
+          'Troppi tentativi ravvicinati. Riprova tra qualche minuto.',
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
       this.logger.error(
         `Failed to resend verification email to ${email}`,
         emailError,
+      );
+      throw new BadRequestException(
+        "Impossibile inviare l'email di verifica. Riprova più tardi.",
       );
     }
   }
@@ -789,40 +817,15 @@ export class UsersService {
    * Test email sending functionality
    */
   /**
-   * TEMP DIAGNOSTIC — pinpoints why generateEmailVerificationLink fails in prod.
-   * firebaseConfig.generateEmailVerificationLink swallows the real Firebase error
-   * code, so here we call the Admin SDK directly with several continueUrl variants
-   * and return the raw error per variant. Remove once the issue is fixed.
+   * Firebase throttles email link generation per IP. When tripped it returns
+   * auth/too-many-requests or an internal-error wrapping TOO_MANY_ATTEMPTS_TRY_LATER.
    */
-  async diagnoseVerificationLink(
-    email: string,
-  ): Promise<{ email: string; results: unknown[] }> {
-    const auth = this.firebaseConfig.getAuth();
-    if (!auth) {
-      return { email, results: [{ ok: false, message: 'Admin SDK null' }] };
-    }
-    const candidates: (string | undefined)[] = [
-      undefined,
-      'https://mindful-sparkle-production.up.railway.app/loginVerified',
-      'https://www.swipick.com/loginVerified',
-    ];
-    const results: unknown[] = [];
-    for (const url of candidates) {
-      try {
-        const acs = url ? { url, handleCodeInApp: false } : undefined;
-        await auth.generateEmailVerificationLink(email, acs);
-        results.push({ url: url ?? '(default/none)', ok: true });
-      } catch (e: unknown) {
-        const err = e as { code?: string; message?: string };
-        results.push({
-          url: url ?? '(default/none)',
-          ok: false,
-          code: err?.code,
-          message: err?.message,
-        });
-      }
-    }
-    return { email, results };
+  private isThrottleError(error: unknown): boolean {
+    const e = error as { code?: string; message?: string };
+    return (
+      e?.code === 'auth/too-many-requests' ||
+      (e?.message ?? '').includes('TOO_MANY_ATTEMPTS_TRY_LATER')
+    );
   }
 
   async testEmailSending(email: string, name: string): Promise<void> {

--- a/apps/frontend/frontend-service/src/components/auth/EmailVerificationPrompt.tsx
+++ b/apps/frontend/frontend-service/src/components/auth/EmailVerificationPrompt.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthContext } from '../../contexts/AuthContext';
 import Button from '../../../components/ui/Button';
@@ -15,7 +15,15 @@ const EmailVerificationPrompt: React.FC = () => {
   const [isResending, setIsResending] = useState(false);
   const [resendSuccess, setResendSuccess] = useState(false);
   const [resendError, setResendError] = useState<string | null>(null);
-  
+  // Cooldown to avoid rapid re-clicks that trip Firebase's per-IP throttle.
+  const [cooldown, setCooldown] = useState(0);
+
+  useEffect(() => {
+    if (cooldown <= 0) return;
+    const t = setTimeout(() => setCooldown((c) => c - 1), 1000);
+    return () => clearTimeout(t);
+  }, [cooldown]);
+
   const { firebaseUser, sendEmailVerification, logout } = useAuthContext();
 
   const handleResendVerification = async () => {
@@ -28,10 +36,17 @@ const EmailVerificationPrompt: React.FC = () => {
     try {
       await sendEmailVerification();
       setResendSuccess(true);
+      setCooldown(60);
       console.log('Verification email resent successfully');
     } catch (error) {
       console.error('Error resending verification email:', error);
-      setResendError('Errore durante l\'invio dell\'email. Riprova più tardi.');
+      // Surface the real backend message (e.g. throttle "riprova tra qualche minuto").
+      setResendError(
+        error instanceof Error && error.message
+          ? error.message
+          : "Errore durante l'invio dell'email. Riprova più tardi.",
+      );
+      setCooldown(30);
     } finally {
       setIsResending(false);
     }
@@ -132,13 +147,15 @@ const EmailVerificationPrompt: React.FC = () => {
               onClick={handleResendVerification}
               variant="secondary"
               fullWidth
-              disabled={isResending}
+              disabled={isResending || cooldown > 0}
             >
               {isResending ? (
                 <>
                   <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-[#554099] mr-2"></div>
                   Invio in corso...
                 </>
+              ) : cooldown > 0 ? (
+                `Riprova tra ${cooldown}s`
               ) : (
                 'Invia Nuovamente'
               )}


### PR DESCRIPTION
## Causa radice (diagnosi conclusa)
L'email di verifica in registrazione non arrivava perché Firebase **throttla** la generazione del link lato server (`TOO_MANY_ATTEMPTS_TRY_LATER`, per IP del backend). L'errore era **ingoiato** → registrazione mostrava "grazie" e il re-invio dava un messaggio generico. (Confermato via endpoint diagnostico temporaneo: tutte le `continueUrl` falliscono con lo stesso errore di throttle; NON è un problema di dominio/SMTP — SMTP e consegna funzionano, mail-tester 9.5/10 con SPF/DKIM/DMARC pass.)

## Modifiche
**BFF (`users.service`)**
- `isThrottleError()` helper.
- **Registrazione**: non fallisce mai per l'email (l'account c'è), ma ora riporta `verificationEmailSent` nella risposta e logga il throttle in modo distinto.
- **resendVerificationEmail** e **sendPasswordReset**: su throttle lanciano **429** "Riprova tra qualche minuto" (il resend fa emergere anche altri fallimenti — lì l'utente è autenticato).
- `user-response.dto`: campo opzionale `verificationEmailSent`.
- Rimosso l'endpoint diagnostico temporaneo.

**Web (`EmailVerificationPrompt`)**
- Mostra il messaggio reale del backend (così il throttle si vede).
- **Cooldown** sul pulsante re-invio (60s su successo / 30s su errore) per non ri-cliccare e ri-triggerare il throttle.

## Verifica
- `tsc` pulito (BFF + web), `eslint` pulito, test `users` 6/6.

## Rinviato (lo segnalo)
- Messaggio `verificationEmailSent` nella registrazione **web** (richiede di propagare il valore attraverso `registerUser`).
- Allineamento **mobile** (stessi messaggi + cooldown) + nuova build.
- Cleanup: cancellare i 2 account di test (`testdiagdue`, `testdiag2026`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)